### PR TITLE
Use a custom descriptor to include default rules in jar-with-dependencies

### DIFF
--- a/CryptoAnalysis/build/descriptor.xml
+++ b/CryptoAnalysis/build/descriptor.xml
@@ -1,0 +1,23 @@
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.0.0 http://maven.apache.org/xsd/assembly-2.0.0.xsd">
+    <id>jar-with-dependencies</id>
+    <formats>
+        <format>jar</format>
+    </formats>
+    <includeBaseDirectory>false</includeBaseDirectory>
+    <dependencySets>
+        <dependencySet>
+            <outputDirectory>/</outputDirectory>
+            <useProjectArtifact>true</useProjectArtifact>
+            <unpack>true</unpack>
+            <scope>runtime</scope>
+        </dependencySet>
+    </dependencySets>
+    <fileSets>
+        <fileSet>
+            <directory>src/test/resources</directory>
+            <outputDirectory>defaultRules</outputDirectory>
+        </fileSet>
+    </fileSets>
+</assembly>

--- a/CryptoAnalysis/pom.xml
+++ b/CryptoAnalysis/pom.xml
@@ -25,9 +25,11 @@
 					</execution>
 				</executions>
 				<configuration>
-					<descriptorRefs>
-						<descriptorRef>jar-with-dependencies</descriptorRef>
-					</descriptorRefs>
+					<descriptors>
+						<!-- custom descriptor is copied from jar-with-dependencies -->
+						<!-- This also copies the rules from test resources as default rules into the jar -->
+						<descriptor>build/descriptor.xml</descriptor>
+					</descriptors>
 					<outputDirectory>build</outputDirectory>
 				</configuration>
 			</plugin>


### PR DESCRIPTION
The changed build takes the rules from test/resources and includes them into the jar-with-dependencies in the defaultRules directory