### PR TITLE
Added option to keep line numbers

### DIFF
--- a/CryptoAnalysis/src/main/java/crypto/HeadlessCryptoScanner.java
+++ b/CryptoAnalysis/src/main/java/crypto/HeadlessCryptoScanner.java
@@ -275,7 +275,7 @@ public abstract class HeadlessCryptoScanner {
 		Options.v().set_output_format(Options.output_format_none);
 		Options.v().set_no_bodies_for_excluded(true);
 		Options.v().set_allow_phantom_refs(true);
-
+		Options.v().set_keep_line_number(true);
 		Options.v().set_prepend_classpath(true);
 		Options.v().set_soot_classpath(sootClassPath() + File.pathSeparator + pathToJCE());
 		Options.v().set_process_dir(Arrays.asList(applicationClassPath().split(File.pathSeparator)));


### PR DESCRIPTION
This fix ensures that line numbers are returned so that they can be used in the IntelliJ plugin to apply markers in the editor. Currently, -1 one is returned when the line number is requested.