### PR TITLE
Fix possible OperationNotSupportedException

### DIFF
--- a/CryptoAnalysis/src/main/java/crypto/analysis/CryptoScanner.java
+++ b/CryptoAnalysis/src/main/java/crypto/analysis/CryptoScanner.java
@@ -5,8 +5,8 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Stopwatch;
 import com.google.common.collect.Lists;
@@ -36,7 +36,7 @@ public abstract class CryptoScanner {
 	private final List<ClassSpecification> specifications = Lists.newLinkedList();
 	private final PredicateHandler predicateHandler = new PredicateHandler(this);
 	private CrySLResultsReporter resultsAggregator = new CrySLResultsReporter();
-	private static final Logger logger = LogManager.getLogger(CryptoScanner.class);
+	private static final Logger logger = LoggerFactory.getLogger(CryptoScanner.class);
 
 	private DefaultValueMap<Node<Statement, Val>, AnalysisSeedWithEnsuredPredicate> seedsWithoutSpec = new DefaultValueMap<Node<Statement, Val>, AnalysisSeedWithEnsuredPredicate>() {
 

--- a/CryptoAnalysis/src/main/java/crypto/analysis/CryptoScanner.java
+++ b/CryptoAnalysis/src/main/java/crypto/analysis/CryptoScanner.java
@@ -36,7 +36,7 @@ public abstract class CryptoScanner {
 	private final List<ClassSpecification> specifications = Lists.newLinkedList();
 	private final PredicateHandler predicateHandler = new PredicateHandler(this);
 	private CrySLResultsReporter resultsAggregator = new CrySLResultsReporter();
-	private static final Logger logger = LogManager.getLogger();
+	private static final Logger logger = LogManager.getLogger(CryptoScanner.class);
 
 	private DefaultValueMap<Node<Statement, Val>, AnalysisSeedWithEnsuredPredicate> seedsWithoutSpec = new DefaultValueMap<Node<Statement, Val>, AnalysisSeedWithEnsuredPredicate>() {
 


### PR DESCRIPTION
For newer Java Versions like Java 11 the parameter less constructor of `LogManager.getLoccer()` might cause an `OperationNotSupportedException`. See [this Stackoverflow post](https://stackoverflow.com/questions/52953483/logmanager-getlogger-is-unable-to-determine-class-name-on-java-11) for details how the error looks like.

In my case I'm having troubles instantiating `new CryptoScanner(){ ... }` in the context of running in the JRE Environment of IntelliJ when the code was compiled with a JDK 11. Hence running an Analysis on IntelliJ IDEs crash.

Normal Applications that run outside the IntelliJ IDE context run fine with the current code however (even setting the executing JRE explicit to the internal IntellIiJ or Android Studio JRE).

As I'm not sure how this issue can be fixed without altering this code (or if it even can be fixed without changing code here) I'd suggest we simply update the line here to be compatible with any Java version.