### PR TITLE
Update pom.xml

### DIFF
--- a/CryptoAnalysis/pom.xml
+++ b/CryptoAnalysis/pom.xml
@@ -189,6 +189,12 @@
 		</plugins>
 	</build>
 	<dependencies>
+		<!-- https://mvnrepository.com/artifact/com.google.inject/guice -->
+		<dependency>
+		    <groupId>com.google.inject</groupId>
+		    <artifactId>guice</artifactId>
+		    <version>3.0</version>
+		</dependency>
 		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>


### PR DESCRIPTION
`The import "com.google.inject.internal.util.Sets" cannot be resolved` is shown while trying to build it. 

Here is the relevant maven build log while trying to build `release 2.3`.

```XML
[INFO] --- maven-compiler-plugin:3.3:compile (default-compile) @ CryptoAnalysis ---
[INFO] Changes detected - recompiling the module!
[INFO] Compiling 77 source files to /Users/removed/git/cognicryptsast/CryptoAnalysis-2.3/CryptoAnalysis/target/classes
[INFO] -------------------------------------------------------------
[ERROR] COMPILATION ERROR :
[INFO] -------------------------------------------------------------
[ERROR] /Users/removed/git/cognicryptsast/CryptoAnalysis-2.3/CryptoAnalysis/src/main/java/crypto/analysis/errors/ForbiddenMethodError.java:[7,39] cannot find symbol
  symbol:   class Sets
  location: package com.google.inject.internal.util
[ERROR] /Users/removed/git/cognicryptsast/CryptoAnalysis-2.3/CryptoAnalysis/src/main/java/crypto/analysis/errors/IncompleteOperationError.java:[13,39] cannot find symbol
  symbol:   class Sets
  location: package com.google.inject.internal.util
[ERROR] /Users/removed/git/cognicryptsast/CryptoAnalysis-2.3/CryptoAnalysis/src/main/java/crypto/analysis/errors/TypestateError.java:[9,39] cannot find symbol
  symbol:   class Sets
  location: package com.google.inject.internal.util
[INFO] 3 errors
```
The change in the pom file is to include the relevant package. 

Please note that the latest version of `com.google.inject` is `4.2.x`, but it will not resolve this error due to structural differences in the inject package. The same applies to `4.1.0` and `4.0` versions.