### PR TITLE
Update CryptoAnalysis for Android

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ AndroidZooApps/
 shippable/
 *.class
 *.temp
+CryptoAnalysis/build/
+

--- a/CryptoAnalysis-Android/pom.xml
+++ b/CryptoAnalysis-Android/pom.xml
@@ -4,11 +4,11 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>de.fraunhofer.iem</groupId>
 	<artifactId>CryptoAnalysis-Android</artifactId>
-	<version>2.4-SNAPSHOT</version>
+	<version>2.6-SNAPSHOT</version>
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<cryptoAnalysisVersion>2.4-SNAPSHOT</cryptoAnalysisVersion>
+		<cryptoAnalysisVersion>2.6-SNAPSHOT</cryptoAnalysisVersion>
 		<flowDroidVersion>2.7.1</flowDroidVersion>
 	</properties>
 	<build>

--- a/CryptoAnalysis-Android/src/main/java/de/fraunhofer/iem/crypto/CogniCryptAndroidAnalysis.java
+++ b/CryptoAnalysis-Android/src/main/java/de/fraunhofer/iem/crypto/CogniCryptAndroidAnalysis.java
@@ -146,13 +146,24 @@ public class CogniCryptAndroidAnalysis {
 	protected List<CryptSLRule> getRules() {
 		List<CryptSLRule> rules = Lists.newArrayList();
 		if (rulesDirectory == null) {
+			
+			// TODO: Create a custom CryptoAnalysisException (or CogniCryptException)
 			throw new RuntimeException(
 					"Please specify a directory the CrySL rules (.cryptslbin Files) are located in.");
 		}
+		
+		// TODO: Why iterate here through all files if CryptoAnalysis could do this
+		// Suggestion: 
+		// List<CryptSLRule> rules = CryptSLRuleReader.readFromSourceFolder(file, recursive: true)
+		// if (rules.isEmpty() {...}
+		// return rules;
+		
 		File[] listFiles = new File(rulesDirectory).listFiles();
 		for (File file : listFiles) {
-			if (file != null && file.getName().endsWith("cryptslbin")) {
-				rules.add(CryptSLRuleReader.readFromFile(file));
+			
+			// TODO: Waiting for global constant in CryptAnalysis
+			if (file != null && file.getName().endsWith("cryptsl")) {
+				rules.add(CryptSLRuleReader.readFromSourceFile(file));
 			}
 		}
 		if (rules.isEmpty())

--- a/CryptoAnalysis-Android/src/main/java/de/fraunhofer/iem/crypto/CogniCryptAndroidAnalysis.java
+++ b/CryptoAnalysis-Android/src/main/java/de/fraunhofer/iem/crypto/CogniCryptAndroidAnalysis.java
@@ -167,9 +167,8 @@ public class CogniCryptAndroidAnalysis {
 			}
 		}
 		if (rules.isEmpty())
-			System.out
-					.println("CogniCrypt did not find any rules to start the analysis for. \n It checked for rules in "
-							+ rulesDirectory);
+			System.out.println("CogniCrypt did not find any rules to start the analysis for. \n "
+					+ "It checked for rules in " + rulesDirectory);
 		return rules;
 	}
 


### PR DESCRIPTION
Fixed compilation/runtime errors when using together with current 2.6-SNAPSHOT and upcomming versions. 

*Keep as PR als long as TODOs in code are open. TBD*