### PR TITLE
Provider detection analysis: Refactoring and small fixes

### DIFF
--- a/CryptoAnalysis/pom.xml
+++ b/CryptoAnalysis/pom.xml
@@ -219,7 +219,7 @@
 		<dependency>
 			<groupId>org.bouncycastle</groupId>
 			<artifactId>bcprov-jdk15on</artifactId>
-			<version>1.60</version>
+			<version>1.62</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/CryptoAnalysis/pom.xml
+++ b/CryptoAnalysis/pom.xml
@@ -83,6 +83,16 @@
 									<outputDirectory>src/main/resources</outputDirectory>
 									<includes>**</includes>
 								</artifactItem>
+								<artifactItem>
+									<groupId>de.upb.cs</groupId>
+  									<artifactId>BouncyCastle-JCA</artifactId>
+ 	 								<version>0.1</version>
+									<classifier>ruleset</classifier>
+									<type>zip</type>
+									<overWrite>true</overWrite>
+									<outputDirectory>src/main/resources</outputDirectory>
+									<includes>**</includes>
+								</artifactItem>
 							</artifactItems>
 						</configuration>
 					</execution>
@@ -184,6 +194,13 @@
 			          <followSymlinks>false</followSymlinks>
 			        </fileset>
 			      </filesets>
+			      <fileset>
+			          <directory>${basedir}/src/main/resources/BouncyCastle-JCA/RulesInBin</directory>
+			          <includes>
+			            <include>**</include>
+			          </includes>
+			          <followSymlinks>false</followSymlinks>
+			        </fileset>
 			    </configuration>
   			</plugin>
 		</plugins>

--- a/CryptoAnalysis/pom.xml
+++ b/CryptoAnalysis/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>de.fraunhofer.iem</groupId>
 	<artifactId>CryptoAnalysis</artifactId>
-	<version>2.7-SNAPSHOT</version>
+	<version>2.7.1-SNAPSHOT</version>
 	
 	<properties>
    	 	<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>  

--- a/CryptoAnalysis/pom.xml
+++ b/CryptoAnalysis/pom.xml
@@ -222,6 +222,12 @@
 			<version>1.62</version>
 			<scope>test</scope>
 		</dependency>
+		<!-- https://mvnrepository.com/artifact/org.bouncycastle/bctls-jdk15on -->
+		<dependency>
+			<groupId>org.bouncycastle</groupId>
+			<artifactId>bctls-jdk15on</artifactId>
+			<version>1.62</version>
+		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-simple</artifactId>

--- a/CryptoAnalysis/src/main/java/crypto/HeadlessCryptoScanner.java
+++ b/CryptoAnalysis/src/main/java/crypto/HeadlessCryptoScanner.java
@@ -260,12 +260,11 @@ public abstract class HeadlessCryptoScanner {
 				if (providerDetection()) {
 					//create a new object to execute the Provider Detection analysis
 					ProviderDetection providerDetection = new ProviderDetection();
-					String detectedProvider = providerDetection.doAnalysis(observableDynamicICFG);
-					String providerRulesDirectory = System.getProperty("user.dir")+File.separator+"src"+File.separator+"main"+
-													File.separator+"resources"+File.separator+detectedProvider;
-					if((detectedProvider != null) && (providerDetection.rulesExist(providerRulesDirectory))) {
+					String rootRulesDirectory = System.getProperty("user.dir")+File.separator+"src"+File.separator+"main"+File.separator+"resources";
+					String detectedProvider = providerDetection.doAnalysis(observableDynamicICFG, rootRulesDirectory);
+					if(detectedProvider != null) {
 						rules.clear();
-						rules.addAll(providerDetection.chooseRules(providerRulesDirectory));
+						rules.addAll(providerDetection.chooseRules(rootRulesDirectory+File.separator+detectedProvider));
 					}
 				}
 				

--- a/CryptoAnalysis/src/main/java/crypto/HeadlessCryptoScanner.java
+++ b/CryptoAnalysis/src/main/java/crypto/HeadlessCryptoScanner.java
@@ -60,6 +60,7 @@ public abstract class HeadlessCryptoScanner {
 	private static CommandLine options;
 	private static boolean PRE_ANALYSIS = false;
 	private static List<CrySLRule> rules;
+	private static String rootRulesDirForProvider;
 	private static final Logger LOGGER = LoggerFactory.getLogger(HeadlessCryptoScanner.class);
 
 	public static enum CG {
@@ -78,7 +79,7 @@ public abstract class HeadlessCryptoScanner {
 		if (options.hasOption("rulesDir")) {
 			String resourcesPath = options.getOptionValue("rulesDir");
 			rules = CrySLRulesetSelector.makeFromPath(new File(resourcesPath), RuleFormat.SOURCE);
-			
+			rootRulesDirForProvider = resourcesPath.substring(0, resourcesPath.lastIndexOf(File.separator));
 		}
 		PRE_ANALYSIS = options.hasOption("preanalysis");
 		final CG callGraphAlogrithm;
@@ -260,11 +261,13 @@ public abstract class HeadlessCryptoScanner {
 				if (providerDetection()) {
 					//create a new object to execute the Provider Detection analysis
 					ProviderDetection providerDetection = new ProviderDetection();
-					String rootRulesDirectory = System.getProperty("user.dir")+File.separator+"src"+File.separator+"main"+File.separator+"resources";
-					String detectedProvider = providerDetection.doAnalysis(observableDynamicICFG, rootRulesDirectory);
+					if(rootRulesDirForProvider == null) {
+						rootRulesDirForProvider = System.getProperty("user.dir")+File.separator+"src"+File.separator+"main"+File.separator+"resources";
+					}
+					String detectedProvider = providerDetection.doAnalysis(observableDynamicICFG, rootRulesDirForProvider);
 					if(detectedProvider != null) {
 						rules.clear();
-						rules.addAll(providerDetection.chooseRules(rootRulesDirectory+File.separator+detectedProvider));
+						rules.addAll(providerDetection.chooseRules(rootRulesDirForProvider+File.separator+detectedProvider));
 					}
 				}
 				

--- a/CryptoAnalysis/src/main/java/crypto/HeadlessCryptoScanner.java
+++ b/CryptoAnalysis/src/main/java/crypto/HeadlessCryptoScanner.java
@@ -257,11 +257,17 @@ public abstract class HeadlessCryptoScanner {
 					reporter.addReportListener(new CSVReporter(csvOutputFile,softwareIdentifier(),rules,callGraphWatch.elapsed(TimeUnit.MILLISECONDS)));
 				}
 				
-//				if (providerDetection()) {
-//					//create a new object to execute the Provider Detection analysis
-//					ProviderDetection providerDetection = new ProviderDetection();
-//					rules = providerDetection.doAnalysis(observableDynamicICFG, rules);
-//				}
+				if (providerDetection()) {
+					//create a new object to execute the Provider Detection analysis
+					ProviderDetection providerDetection = new ProviderDetection();
+					String detectedProvider = providerDetection.doAnalysis(observableDynamicICFG);
+					String providerRulesDirectory = System.getProperty("user.dir")+File.separator+"src"+File.separator+"main"+
+													File.separator+"resources"+File.separator+detectedProvider;
+					if((detectedProvider != null) && (providerDetection.rulesExist(providerRulesDirectory))) {
+						rules.clear();
+						rules.addAll(providerDetection.chooseRules(providerRulesDirectory));
+					}
+				}
 				
 				scanner.scan(rules);
 			}

--- a/CryptoAnalysis/src/main/java/crypto/HeadlessCryptoScanner.java
+++ b/CryptoAnalysis/src/main/java/crypto/HeadlessCryptoScanner.java
@@ -257,11 +257,11 @@ public abstract class HeadlessCryptoScanner {
 					reporter.addReportListener(new CSVReporter(csvOutputFile,softwareIdentifier(),rules,callGraphWatch.elapsed(TimeUnit.MILLISECONDS)));
 				}
 				
-				if (providerDetection()) {
-					//create a new object to execute the Provider Detection analysis
-					ProviderDetection providerDetection = new ProviderDetection();
-					rules = providerDetection.doAnalysis(observableDynamicICFG, rules);
-				}
+//				if (providerDetection()) {
+//					//create a new object to execute the Provider Detection analysis
+//					ProviderDetection providerDetection = new ProviderDetection();
+//					rules = providerDetection.doAnalysis(observableDynamicICFG, rules);
+//				}
 				
 				scanner.scan(rules);
 			}

--- a/CryptoAnalysis/src/main/java/crypto/HeadlessCryptoScanner.java
+++ b/CryptoAnalysis/src/main/java/crypto/HeadlessCryptoScanner.java
@@ -391,7 +391,7 @@ public abstract class HeadlessCryptoScanner {
 	}
 	
 	protected boolean providerDetection() {
-		return false;
+		return true;
 	}
 	
 	private static String pathToJCE() {

--- a/CryptoAnalysis/src/main/java/crypto/analysis/CrySLRulesetSelector.java
+++ b/CryptoAnalysis/src/main/java/crypto/analysis/CrySLRulesetSelector.java
@@ -87,7 +87,7 @@ public class CrySLRulesetSelector {
 
 	public static List<CrySLRule> makeFromPath(File resourcesPath, RuleFormat ruleFormat) {
 		if (!resourcesPath.isDirectory())
-			throw new RuntimeException("The specified path is not a directory" + resourcesPath);
+			System.out.println("The specified path is not a directory " + resourcesPath);
 		List<CrySLRule> rules = Lists.newArrayList();
 		File[] listFiles = resourcesPath.listFiles();
 		for (File file : listFiles) {

--- a/CryptoAnalysis/src/main/java/crypto/analysis/CrySLRulesetSelector.java
+++ b/CryptoAnalysis/src/main/java/crypto/analysis/CrySLRulesetSelector.java
@@ -67,7 +67,10 @@ public class CrySLRulesetSelector {
 		List<CrySLRule> rules = Lists.newArrayList();
 		File[] listFiles = new File(rulesBasePath + s + "/").listFiles();
 		for (File file : listFiles) {
-			rules.add(CrySLRuleReader.readFromSourceFile(file));
+			CrySLRule rule = CrySLRuleReader.readFromSourceFile(file);
+			if(rule != null) {
+				rules.add(rule);
+			}
 		}
 		return rules;
 	}

--- a/CryptoAnalysis/src/main/java/crypto/analysis/CrySLRulesetSelector.java
+++ b/CryptoAnalysis/src/main/java/crypto/analysis/CrySLRulesetSelector.java
@@ -91,7 +91,10 @@ public class CrySLRulesetSelector {
 		List<CrySLRule> rules = Lists.newArrayList();
 		File[] listFiles = resourcesPath.listFiles();
 		for (File file : listFiles) {
-			rules.add(CrySLRuleReader.readFromSourceFile(file));
+			CrySLRule rule = CrySLRuleReader.readFromSourceFile(file);
+			if(rule != null) {
+				rules.add(rule);
+			}
 		}
 		if (rules.isEmpty()) {
 			System.out.println("No CrySL rules found in " + resourcesPath);

--- a/CryptoAnalysis/src/main/java/crypto/cryslhandler/CrySLModelReader.java
+++ b/CryptoAnalysis/src/main/java/crypto/cryslhandler/CrySLModelReader.java
@@ -120,8 +120,7 @@ public class CrySLModelReader {
 
 	public CrySLRule readRule(File ruleFile) {
 		final String fileName = ruleFile.getName();
-		final String extension = fileName.substring(fileName.lastIndexOf("."));
-		if (!cryslFileEnding.equals(extension)) {
+		if (!fileName.endsWith(cryslFileEnding)) {
 			return null;
 		}
 		final Resource resource = resourceSet.getResource(URI.createFileURI(ruleFile.getAbsolutePath()), true);// URI.createPlatformResourceURI(ruleFile.getFullPath().toPortableString(), // true), true);

--- a/CryptoAnalysis/src/main/java/crypto/providerdetection/ProviderDetection.java
+++ b/CryptoAnalysis/src/main/java/crypto/providerdetection/ProviderDetection.java
@@ -9,9 +9,12 @@
 package crypto.providerdetection;
 
 import java.io.File;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -53,6 +56,8 @@ public class ProviderDetection {
 	private String provider = null;
 	private String rulesDirectory = null;	
 	private static final String BOUNCY_CASTLE = "BouncyCastle";
+	private static final String[] PROVIDER_VALUES = new String[] {"BC", "BCPQC", "BCJSSE"};
+	private static final Set<String> SUPPORTED_PROVIDERS = new HashSet<>(Arrays.asList(PROVIDER_VALUES));
 	
 	
 	public String getProvider() {
@@ -115,6 +120,11 @@ public class ProviderDetection {
 									}
 										
 									else if (providerType.matches("java.lang.String")) {
+										if(SUPPORTED_PROVIDERS.contains(providerValue.toString().replaceAll("\"",""))) {
+											if(providerValue.toString().replaceAll("\"","").contains("BC")) {
+												return "BouncyCastle-JCA";
+											}
+										}
 										this.provider = getProviderWhenTypeString(providerValue, body);
 										
 										// Gets the boolean value of whether the provider is passed

--- a/CryptoAnalysis/src/main/java/crypto/providerdetection/ProviderDetection.java
+++ b/CryptoAnalysis/src/main/java/crypto/providerdetection/ProviderDetection.java
@@ -69,15 +69,12 @@ public class ProviderDetection {
 	
 	
 	/**
-	 * This method does the Provider Detection analysis and returns the detected set 
-	 * of CrySL rules after the analysis is finished. If no Provider is detected, 
-	 * it returns the default set of CrySL rules. Otherwise it returns all CrySL 
-	 * rules for that provider, plus additional default CrySL rules that were not 
-	 * yet implemented for the detected provider
+	 * This method does the Provider Detection analysis and returns the detected 
+	 * provider after the analysis is finished. If no Provider is detected, 
+	 * then it will return null value, meaning that there was no provider used.
 	 * 
 	 * @param icfg
 	 *            
-	 * @param rules 
 	 */
 	public String doAnalysis(ObservableICFG<Unit, SootMethod> observableDynamicICFG) {
 		
@@ -140,7 +137,7 @@ public class ProviderDetection {
 	
 	/**
 	 * This method returns the type of Provider detected, since
-	 * it can be either `java.security.Provider` or `java.lang.String`
+	 * it can be either `java.security.Provider` or `java.lang.String`.
 	 * 
 	 * @param providerValue
 	 */
@@ -151,7 +148,7 @@ public class ProviderDetection {
 	
 	
 	/**
-	 * This method return the provider used when Provider detected is of type `java.security.Provider`
+	 * This method return the provider used when Provider detected is of type `java.security.Provider`.
 	 * 
 	 * @param statement
 	 *            
@@ -225,7 +222,7 @@ public class ProviderDetection {
 	
 	
 	/**
-	 * This method return the provider used when Provider detected is of type `java.lang.String`
+	 * This method return the provider used when Provider detected is of type `java.lang.String`.
 	 * 
 	 * @param providerValue
 	 *            
@@ -308,26 +305,33 @@ public class ProviderDetection {
 		return false;
 	}
 	
+	/**
+	 * This method is used to check if the CryptSL rules from the detected Provider do exist and
+	 * should be called after the `doAnalysis()` method, but before the `chooseRules()` method.
+	 * 
+	 * @param providerRulesDirectory
+	 * 
+	 */
+	public boolean rulesExist(String providerRulesDirectory) {
+		File rulesDirectory = new File(providerRulesDirectory);
+		if(rulesDirectory.exists()) {
+			return true;
+		}
+		return false;
+	}
+	
 	
 	/**
-	 * This method is used to choose the CrySL rules from the detected Provider
-	 * 
-	 * @param rules
+	 * This method is used to choose the CryptSL rules from the detected Provider and should
+	 * be called after the `doAnalysis()` and `rulesExist()` methods, in that respective order.
 	 *            
-	 * @param provider
-	 *            - i.e. BC
-	 * @param declaringClassName
-	 * 			  - i.e. MessageDigest
+	 * @param providerRulesDirectory
+	 *          
 	 */
 	public List<CrySLRule> chooseRules(String providerRulesDirectory) {
 		List<CrySLRule> rules = Lists.newArrayList();
-		rules = null;
-		File rulesDirectory = new File(providerRulesDirectory);
-		if(rulesDirectory.exists()) {
-			this.rulesDirectory = providerRulesDirectory;
-			rules = CrySLRulesetSelector.makeFromPath(new File(providerRulesDirectory), RuleFormat.SOURCE);
-			return rules;
-		}
+		this.rulesDirectory = providerRulesDirectory;
+		rules = CrySLRulesetSelector.makeFromPath(new File(providerRulesDirectory), RuleFormat.SOURCE);
 		return rules;
 	}
 		  

--- a/CryptoAnalysis/src/main/java/crypto/providerdetection/ProviderDetection.java
+++ b/CryptoAnalysis/src/main/java/crypto/providerdetection/ProviderDetection.java
@@ -357,6 +357,7 @@ public class ProviderDetection {
 				if(assignStatement.getLeftOp().equals(providerValue)) {
 					String provider = assignStatement.getRightOp().toString().replaceAll("\"","");
 					if(provider.equals("BC") || provider.equals("BCPQC") || provider.equals("BCJSSE")) {
+						provider = "BC";
 						return provider;
 					}
 				}

--- a/CryptoAnalysis/src/main/java/crypto/providerdetection/ProviderDetection.java
+++ b/CryptoAnalysis/src/main/java/crypto/providerdetection/ProviderDetection.java
@@ -121,9 +121,7 @@ public class ProviderDetection {
 										
 									else if (providerType.matches("java.lang.String")) {
 										if(SUPPORTED_PROVIDERS.contains(providerValue.toString().replaceAll("\"",""))) {
-											if(providerValue.toString().replaceAll("\"","").contains("BC")) {
-												return "BouncyCastle-JCA";
-											}
+											return "BouncyCastle-JCA";
 										}
 										this.provider = getProviderWhenTypeString(providerValue, body);
 										

--- a/CryptoAnalysis/src/main/java/crypto/providerdetection/ProviderDetection.java
+++ b/CryptoAnalysis/src/main/java/crypto/providerdetection/ProviderDetection.java
@@ -75,7 +75,7 @@ public class ProviderDetection {
 	private static final String sootClassPath = System.getProperty("user.dir") + File.separator+"target"+File.separator+"test-classes";
 	
 	private static final String CRYSL = RuleFormat.SOURCE.toString();
-	private static final String BOUNCY_CASTLE = "BouncyCastleProvider";
+	private static final String BOUNCY_CASTLE = "BouncyCastle";
 	
 	
 	public String getProvider() {
@@ -355,7 +355,10 @@ public class ProviderDetection {
 			if(unit instanceof JAssignStmt) {
 				JAssignStmt assignStatement = (JAssignStmt) unit;
 				if(assignStatement.getLeftOp().equals(providerValue)) {
-					return assignStatement.getRightOp().toString().replaceAll("\"","");
+					String provider = assignStatement.getRightOp().toString().replaceAll("\"","");
+					if(provider.equals("BC") || provider.equals("BCPQC") || provider.equals("BCJSSE")) {
+						return provider;
+					}
 				}
 			}
 		}

--- a/CryptoAnalysis/src/main/java/crypto/providerdetection/ProviderDetection.java
+++ b/CryptoAnalysis/src/main/java/crypto/providerdetection/ProviderDetection.java
@@ -9,14 +9,10 @@
 package crypto.providerdetection;
 
 import java.io.File;
-import java.net.MalformedURLException;
-import java.util.ArrayList;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -27,30 +23,19 @@ import boomerang.BackwardQuery;
 import boomerang.Boomerang;
 import boomerang.DefaultBoomerangOptions;
 import boomerang.ForwardQuery;
-import boomerang.callgraph.ObservableDynamicICFG;
 import boomerang.callgraph.ObservableICFG;
 import boomerang.jimple.Statement;
 import boomerang.jimple.Val;
-import boomerang.preanalysis.BoomerangPretransformer;
 import boomerang.results.AbstractBoomerangResults;
 import boomerang.results.BackwardBoomerangResults;
 import boomerang.seedfactory.SeedFactory;
 import crypto.analysis.CrySLRulesetSelector.RuleFormat;
-import crypto.analysis.CrySLRulesetSelector.Ruleset;
 import crypto.rules.CrySLRule;
-import crypto.rules.CrySLRuleReader;
 import crypto.analysis.CrySLRulesetSelector;
-import crypto.analysis.CrySLRulesetSelector.RuleFormat;
-import crypto.analysis.CrySLRulesetSelector.Ruleset;
 import soot.Body;
-import soot.G;
-import soot.PackManager;
 import soot.Scene;
-import soot.SceneTransformer;
 import soot.SootClass;
 import soot.SootMethod;
-import soot.Transform;
-import soot.Transformer;
 import soot.Type;
 import soot.Unit;
 import soot.Value;
@@ -59,7 +44,6 @@ import soot.jimple.TableSwitchStmt;
 import soot.jimple.internal.JAssignStmt;
 import soot.jimple.internal.JIfStmt;
 import soot.jimple.internal.JStaticInvokeExpr;
-import soot.options.Options;
 import wpds.impl.Weight.NoWeight;
 
 public class ProviderDetection {
@@ -67,14 +51,7 @@ public class ProviderDetection {
 	private static final Logger LOGGER = LoggerFactory.getLogger(ProviderDetection.class);
 	
 	private String provider = null;
-	private String rulesDirectory = null;
-	
-	private static final Ruleset defaultRuleset = Ruleset.JavaCryptographicArchitecture;
-	private static final String rootRulesDirectory = System.getProperty("user.dir")+File.separator+"src"+File.separator+"main"+File.separator+"resources";
-	private static final String defaultRulesDirectory = rootRulesDirectory+File.separator+defaultRuleset;
-	private static final String sootClassPath = System.getProperty("user.dir") + File.separator+"target"+File.separator+"test-classes";
-	
-	private static final String CRYSL = RuleFormat.SOURCE.toString();
+	private String rulesDirectory = null;	
 	private static final String BOUNCY_CASTLE = "BouncyCastle";
 	
 	
@@ -86,80 +63,10 @@ public class ProviderDetection {
 		return rulesDirectory;
 	}
 	
-	
-	/**
-	 * This method is used to get the Soot classpath from `src/test/java`
-	 * in order to run the JUnit test cases for Provider Detection
-	 */
-	public String getSootClassPath(){
-		//Assume target folder to be directly in user directory
-		File classPathDir = new File(sootClassPath);
-		if (!classPathDir.exists()){
-			throw new RuntimeException("Classpath for the test cases could not be found.");
-		}
-		return sootClassPath;
+	protected void setRulesDirectory(String rulesDirectory) {
+		this.rulesDirectory = rulesDirectory;
 	}
 	
-	/**
-	 * This method is used to setup Soot
-	 */
-	public void setupSoot(String sootClassPath, String mainClass) {
-		G.v().reset();
-		Options.v().set_whole_program(true);
-		Options.v().setPhaseOption("cg.cha", "on");
-//		Options.v().setPhaseOption("cg", "all-reachable:true");
-		Options.v().set_output_format(Options.output_format_none);
-		Options.v().set_no_bodies_for_excluded(true);
-		Options.v().set_allow_phantom_refs(true);
-		Options.v().set_keep_line_number(true);
-		Options.v().set_prepend_classpath(true);
-		Options.v().set_soot_classpath(sootClassPath);
-		SootClass c = Scene.v().forceResolve(mainClass, SootClass.BODIES);
-		if (c != null) {
-			c.setApplicationClass();
-		}
-
-		List<String> includeList = new LinkedList<String>();
-		includeList.add("java.lang.AbstractStringBuilder");
-		includeList.add("java.lang.Boolean");
-		includeList.add("java.lang.Byte");
-		includeList.add("java.lang.Class");
-		includeList.add("java.lang.Integer");
-		includeList.add("java.lang.Long");
-		includeList.add("java.lang.Object");
-		includeList.add("java.lang.String");
-		includeList.add("java.lang.StringCoding");
-		includeList.add("java.lang.StringIndexOutOfBoundsException");
-
-		Options.v().set_include(includeList);
-		Options.v().set_full_resolver(true);
-		Scene.v().loadNecessaryClasses();
-	}
-	
-	
-	public void analyze() {
-		Transform transform = new Transform("wjtp.ifds", createAnalysisTransformer());
-		PackManager.v().getPack("wjtp").add(transform);
-		PackManager.v().getPack("cg").apply();
-		PackManager.v().getPack("wjtp").apply();
-	}
-	
-	
-	private Transformer createAnalysisTransformer() {
-		return new SceneTransformer() {
-			
-			@Override
-			protected void internalTransform(String phaseName, @SuppressWarnings("rawtypes") Map options) {
-				BoomerangPretransformer.v().reset();
-				BoomerangPretransformer.v().apply();
-				ObservableDynamicICFG observableDynamicICFG = new ObservableDynamicICFG(false);
-				List<CrySLRule> defaultCryptoRules = Lists.newArrayList();
-				defaultCryptoRules = CrySLRulesetSelector.makeFromPath(new File(defaultRulesDirectory), RuleFormat.SOURCE);
-				doAnalysis(observableDynamicICFG, defaultCryptoRules);
-			}
-		};
-	}
-
 	
 	/**
 	 * This method does the Provider Detection analysis and returns the detected set 
@@ -172,9 +79,8 @@ public class ProviderDetection {
 	 *            
 	 * @param rules 
 	 */
-	public List<CrySLRule> doAnalysis(ObservableICFG<Unit, SootMethod> observableDynamicICFG, List<CrySLRule> rules) {
+	public String doAnalysis(ObservableICFG<Unit, SootMethod> observableDynamicICFG) {
 		
-		outerloop:
 		for(SootClass sootClass : Scene.v().getApplicationClasses()) {
 			for(SootMethod sootMethod : sootClass.getMethods()) {
 				if(sootMethod.hasActiveBody()) {
@@ -195,48 +101,25 @@ public class ProviderDetection {
 									
 								int methodParameterCount = method.getParameterCount();
 								
-								// List of all CrySL rules
-								List<String> availableCrySLRules = new ArrayList<String>();
-								
-								for(CrySLRule rule : rules) {
-									String ruleName = rule.getClassName().substring(rule.getClassName().lastIndexOf(".") + 1);
-									availableCrySLRules.add(ruleName);
-								}
-									
-								// Checks if detected declaring class is implemented as a CrySL rule
-								boolean ruleFound = availableCrySLRules.contains(declaringClassName);
-									
-								if((ruleFound) && (methodName.matches("getInstance")) && (methodParameterCount==2) ) {
+								if((methodName.matches("getInstance")) && (methodParameterCount==2) ) {
 									// Gets the second parameter from getInstance() method, since it is the provider parameter
 									Value providerValue = expression.getArg(1);
 									String providerType = getProviderType(providerValue);
 										
 									if(providerType.matches("java.security.Provider")) {
 										this.provider = getProviderWhenTypeProvider(statement, sootMethod, providerValue, observableDynamicICFG);
-										this.rulesDirectory = defaultRulesDirectory;
-										
-										if((this.provider != null) && (ruleExists(provider, declaringClassName))) {
-											this.rulesDirectory = rootRulesDirectory+File.separator+provider;
-											
-											rules = chooseRules(rules, provider, declaringClassName);
-											break outerloop;
-										}
+										return this.provider;
 									}
 										
 									else if (providerType.matches("java.lang.String")) {
-										this.provider = getProviderWhenTypeString(providerValue, body);
-										rulesDirectory = defaultRulesDirectory;
-										
 										// Gets the boolean value of whether the provider is passed
 										// using IF-ELSE, SWITCH statements or TERNARY operators
 										boolean ifStmt = checkIfStmt(providerValue, body);
 										boolean switchStmt = checkSwitchStmt(providerValue, body);
 										
-										if((!ifStmt) && (!switchStmt) && (this.provider != null) && (ruleExists(provider, declaringClassName))) {
-											this.rulesDirectory = rootRulesDirectory+File.separator+provider;
-											
-											rules = chooseRules(rules, provider, declaringClassName);
-											break outerloop;
+										if((!ifStmt) && (!switchStmt)) {
+											this.provider = getProviderWhenTypeString(providerValue, body);
+											return this.provider;
 										}
 									}
 								}
@@ -247,7 +130,7 @@ public class ProviderDetection {
 			}
 		}
 	 			
-		return rules;
+		return this.provider;
 	}
 	
 	
@@ -427,33 +310,6 @@ public class ProviderDetection {
 	
 	
 	/**
-	 * This method is used to check if the CrySL rule for the detected provider exists
-	 * 
-	 * @param provider
-	 *            - i.e. BC
-	 * @param declaringClassName
-	 *            - i.e. MessageDigest
-	 */
-	private boolean ruleExists(String provider, String declaringClassName) {
-		boolean ruleExists = false;
-		String rule = declaringClassName;
-		
-		File rulesDirectory = new File(rootRulesDirectory+File.separator+provider);
-		if(rulesDirectory.exists()) {
-			File[] listRulesDirectoryFiles = rulesDirectory.listFiles();
-			for (File file : listRulesDirectoryFiles) {
-				if (file != null && file.getAbsolutePath().endsWith(rule+CRYSL)) {
-					ruleExists = true;
-					break;
-				}
-			}
-		}
-		
-		return ruleExists;
-	}
-	
-	
-	/**
 	 * This method is used to choose the CrySL rules from the detected Provider
 	 * 
 	 * @param rules
@@ -463,40 +319,16 @@ public class ProviderDetection {
 	 * @param declaringClassName
 	 * 			  - i.e. MessageDigest
 	 */
-	private List<CrySLRule> chooseRules(List<CrySLRule> rules, String provider, String declaringClassName) {
-		
-		String newRulesDirectory = rootRulesDirectory+File.separator+provider;
-		
-		// Forms a list of all the new CrySL rules in the detected provider's directory.
-		// This list contains only String elements and it holds only the rule's names, i.e Cipher, MessageDigest, etc
-		List<String> newRules = new ArrayList<String>();
-		File[] files = new File(newRulesDirectory).listFiles();
-		for (File file : files) {
-		    if (file.isFile() && file.getName().endsWith(CRYSL)) {
-		        newRules.add(StringUtils.substringBefore(file.getName(), "."));
-		    }
+	public List<CrySLRule> chooseRules(String providerRulesDirectory) {
+		List<CrySLRule> rules = Lists.newArrayList();
+		rules = null;
+		File rulesDirectory = new File(providerRulesDirectory);
+		if(rulesDirectory.exists()) {
+			this.rulesDirectory = providerRulesDirectory;
+			rules = CrySLRulesetSelector.makeFromPath(new File(providerRulesDirectory), RuleFormat.SOURCE);
+			return rules;
 		}
-		
-		// A new CrySL rules list is created which will contain all the new rules.
-		// Firstly, all the default rules that are not present in the detected provider's rules are added.
-		// e.g if Cipher rule is not present in the detected provider's directory, then the default Cipher rule
-		// is added to the new CrySL rules list
-		List<CrySLRule> newCrySLRules = Lists.newArrayList();
-		for(CrySLRule rule : rules) {
-			String ruleName = rule.getClassName().substring(rule.getClassName().lastIndexOf(".") + 1);
-			if(!newRules.contains(ruleName)) {
-				newCrySLRules.add(rule);
-			}
-		}
-		
-		// At the end, the remaining CrySL rules from the detected provider's directory
-		// are added to the new CrySL rules list
-		File[] listFiles = new File(newRulesDirectory).listFiles();
-		for (File file : listFiles) {
-			if (file != null && file.getName().endsWith(CRYSL)) {
-				newCrySLRules.add(CrySLRuleReader.readFromSourceFile(file));
-			}
-		}
-		return newCrySLRules;
+		return rules;
 	}
+		  
 }

--- a/CryptoAnalysis/src/main/java/crypto/providerdetection/ProviderDetection.java
+++ b/CryptoAnalysis/src/main/java/crypto/providerdetection/ProviderDetection.java
@@ -216,7 +216,7 @@ public class ProviderDetection {
 										this.rulesDirectory = defaultRulesDirectory;
 										
 										if((this.provider != null) && (ruleExists(provider, declaringClassName))) {
-											this.rulesDirectory = defaultRulesDirectory+File.separator+provider;
+											this.rulesDirectory = rootRulesDirectory+File.separator+provider;
 											
 											rules = chooseRules(rules, provider, declaringClassName);
 											break outerloop;
@@ -233,7 +233,7 @@ public class ProviderDetection {
 										boolean switchStmt = checkSwitchStmt(providerValue, body);
 										
 										if((!ifStmt) && (!switchStmt) && (this.provider != null) && (ruleExists(provider, declaringClassName))) {
-											rulesDirectory = defaultRulesDirectory+File.separator+provider;
+											this.rulesDirectory = rootRulesDirectory+File.separator+provider;
 											
 											rules = chooseRules(rules, provider, declaringClassName);
 											break outerloop;
@@ -324,7 +324,7 @@ public class ProviderDetection {
 				
 				// In here are listed all the supported providers so far
 				if(valueTypeString.contains(BOUNCY_CASTLE)) {
-					provider = "BC";
+					provider = "BouncyCastle-JCA";
 				}
 			}
 		}
@@ -357,7 +357,7 @@ public class ProviderDetection {
 				if(assignStatement.getLeftOp().equals(providerValue)) {
 					String provider = assignStatement.getRightOp().toString().replaceAll("\"","");
 					if(provider.equals("BC") || provider.equals("BCPQC") || provider.equals("BCJSSE")) {
-						provider = "BC";
+						provider = "BouncyCastle-JCA";
 						return provider;
 					}
 				}
@@ -438,7 +438,7 @@ public class ProviderDetection {
 		boolean ruleExists = false;
 		String rule = declaringClassName;
 		
-		File rulesDirectory = new File(defaultRulesDirectory+File.separator+provider);
+		File rulesDirectory = new File(rootRulesDirectory+File.separator+provider);
 		if(rulesDirectory.exists()) {
 			File[] listRulesDirectoryFiles = rulesDirectory.listFiles();
 			for (File file : listRulesDirectoryFiles) {
@@ -465,7 +465,7 @@ public class ProviderDetection {
 	 */
 	private List<CrySLRule> chooseRules(List<CrySLRule> rules, String provider, String declaringClassName) {
 		
-		String newRulesDirectory = defaultRulesDirectory+File.separator+provider;
+		String newRulesDirectory = rootRulesDirectory+File.separator+provider;
 		
 		// Forms a list of all the new CrySL rules in the detected provider's directory.
 		// This list contains only String elements and it holds only the rule's names, i.e Cipher, MessageDigest, etc

--- a/CryptoAnalysis/src/main/java/crypto/providerdetection/ProviderDetection.java
+++ b/CryptoAnalysis/src/main/java/crypto/providerdetection/ProviderDetection.java
@@ -499,28 +499,4 @@ public class ProviderDetection {
 		}
 		return newCrySLRules;
 	}
-	
-	
-	/**
-	 * This method is used to get all the default CrySL rules
-	 * 
-	 * @param rulesDirectory
-	 * 
-	 * @param rules
-	 */
-	private List<CrySLRule> getRules(String rulesDirectory, List<CrySLRule> rules) {
-		File directory = new File(rulesDirectory);
-		
-		File[] listFiles = directory.listFiles();
-		for (File file : listFiles) {
-			if (file != null && file.getName().endsWith(CRYSL)) {
-				rules.add(CrySLRuleReader.readFromSourceFile(file));
-			}
-		}
-		if (rules.isEmpty())
-			System.out.println("Did not find any rules to start the analysis for. \n It checked for rules in "+ rulesDirectory);
-		
-		return rules;
-	}
-	//-----------------------------------------------------------------------------------------------------------------
 }

--- a/CryptoAnalysis/src/test/java/tests/providerdetection/ProviderDetectionTestingFramework.java
+++ b/CryptoAnalysis/src/test/java/tests/providerdetection/ProviderDetectionTestingFramework.java
@@ -1,0 +1,114 @@
+package tests.providerdetection;
+
+import java.io.File;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+import com.google.common.collect.Lists;
+
+import boomerang.callgraph.ObservableDynamicICFG;
+import boomerang.preanalysis.BoomerangPretransformer;
+import crypto.analysis.CrySLRulesetSelector;
+import crypto.analysis.CrySLRulesetSelector.RuleFormat;
+import crypto.analysis.CrySLRulesetSelector.Ruleset;
+import crypto.providerdetection.ProviderDetection;
+import crypto.rules.CrySLRule;
+import soot.G;
+import soot.PackManager;
+import soot.Scene;
+import soot.SceneTransformer;
+import soot.SootClass;
+import soot.Transform;
+import soot.Transformer;
+import soot.options.Options;
+
+public class ProviderDetectionTestingFramework extends ProviderDetection {
+	
+	private static final Ruleset defaultRuleset = Ruleset.JavaCryptographicArchitecture;
+	private static final String rootRulesDirectory = System.getProperty("user.dir")+File.separator+"src"+File.separator+"main"+File.separator+"resources";
+	private static final String defaultRulesDirectory = rootRulesDirectory+File.separator+defaultRuleset;
+	private static final String sootClassPath = System.getProperty("user.dir") + File.separator+"target"+File.separator+"test-classes";
+	
+	/**
+	 * This method is used to get the Soot classpath from `src/test/java`
+	 * in order to run the JUnit test cases for Provider Detection
+	 */
+	public String getSootClassPath(){
+		//Assume target folder to be directly in user directory
+		File classPathDir = new File(sootClassPath);
+		if (!classPathDir.exists()){
+			throw new RuntimeException("Classpath for the test cases could not be found.");
+		}
+		return sootClassPath;
+	}
+	
+	
+	/**
+	 * This method is used to setup Soot
+	 */
+	public void setupSoot(String sootClassPath, String mainClass) {
+		G.v().reset();
+		Options.v().set_whole_program(true);
+		Options.v().setPhaseOption("cg.cha", "on");
+//		Options.v().setPhaseOption("cg", "all-reachable:true");
+		Options.v().set_output_format(Options.output_format_none);
+		Options.v().set_no_bodies_for_excluded(true);
+		Options.v().set_allow_phantom_refs(true);
+		Options.v().set_keep_line_number(true);
+		Options.v().set_prepend_classpath(true);
+		Options.v().set_soot_classpath(sootClassPath);
+		SootClass c = Scene.v().forceResolve(mainClass, SootClass.BODIES);
+		if (c != null) {
+			c.setApplicationClass();
+		}
+
+		List<String> includeList = new LinkedList<String>();
+		includeList.add("java.lang.AbstractStringBuilder");
+		includeList.add("java.lang.Boolean");
+		includeList.add("java.lang.Byte");
+		includeList.add("java.lang.Class");
+		includeList.add("java.lang.Integer");
+		includeList.add("java.lang.Long");
+		includeList.add("java.lang.Object");
+		includeList.add("java.lang.String");
+		includeList.add("java.lang.StringCoding");
+		includeList.add("java.lang.StringIndexOutOfBoundsException");
+
+		Options.v().set_include(includeList);
+		Options.v().set_full_resolver(true);
+		Scene.v().loadNecessaryClasses();
+	}
+	
+	
+	public void analyze() {
+		Transform transform = new Transform("wjtp.ifds", createAnalysisTransformer());
+		PackManager.v().getPack("wjtp").add(transform);
+		PackManager.v().getPack("cg").apply();
+		PackManager.v().getPack("wjtp").apply();
+	}
+	
+	
+	private Transformer createAnalysisTransformer() {
+		return new SceneTransformer() {
+			
+			@Override
+			protected void internalTransform(String phaseName, @SuppressWarnings("rawtypes") Map options) {
+				BoomerangPretransformer.v().reset();
+				BoomerangPretransformer.v().apply();
+				ObservableDynamicICFG observableDynamicICFG = new ObservableDynamicICFG(false);
+				doAnalysis(observableDynamicICFG);
+				getRules();
+			}
+		};
+	}
+	
+	private void getRules() {
+		super.setRulesDirectory(defaultRulesDirectory);
+		String detectedProvider = super.getProvider();
+		if(detectedProvider != null) {
+			super.chooseRules(rootRulesDirectory+File.separator+detectedProvider);
+		}
+	}
+	
+}

--- a/CryptoAnalysis/src/test/java/tests/providerdetection/ProviderDetectionTestingFramework.java
+++ b/CryptoAnalysis/src/test/java/tests/providerdetection/ProviderDetectionTestingFramework.java
@@ -5,15 +5,10 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
-import com.google.common.collect.Lists;
-
 import boomerang.callgraph.ObservableDynamicICFG;
 import boomerang.preanalysis.BoomerangPretransformer;
-import crypto.analysis.CrySLRulesetSelector;
-import crypto.analysis.CrySLRulesetSelector.RuleFormat;
 import crypto.analysis.CrySLRulesetSelector.Ruleset;
 import crypto.providerdetection.ProviderDetection;
-import crypto.rules.CrySLRule;
 import soot.G;
 import soot.PackManager;
 import soot.Scene;
@@ -97,18 +92,10 @@ public class ProviderDetectionTestingFramework extends ProviderDetection {
 				BoomerangPretransformer.v().reset();
 				BoomerangPretransformer.v().apply();
 				ObservableDynamicICFG observableDynamicICFG = new ObservableDynamicICFG(false);
-				doAnalysis(observableDynamicICFG);
-				getRules();
+				setRulesDirectory(defaultRulesDirectory);
+				doAnalysis(observableDynamicICFG, rootRulesDirectory);
 			}
 		};
-	}
-	
-	private void getRules() {
-		super.setRulesDirectory(defaultRulesDirectory);
-		String detectedProvider = super.getProvider();
-		if(detectedProvider != null) {
-			super.chooseRules(rootRulesDirectory+File.separator+detectedProvider);
-		}
 	}
 	
 }

--- a/CryptoAnalysis/src/test/java/tests/providerdetection/ProviderDetectionTests.java
+++ b/CryptoAnalysis/src/test/java/tests/providerdetection/ProviderDetectionTests.java
@@ -67,7 +67,7 @@ public class ProviderDetectionTests {
 	}
 	
 	// Checks if rules are correctly extracted, when provider is of type `java.security.Provider`,
-	// is given as a variable, and the rules for that provider do not exist => so it takes Default rules
+	// is given as a variable, and the rules for that provider exist
 	@Test
 	public void providerDetectionTest5() {
 		ProviderDetection providerDetection = new ProviderDetection();
@@ -77,11 +77,11 @@ public class ProviderDetectionTests {
 		providerDetection.analyze();
 		
 		String rulesDirectory = providerDetection.getRulesDirectory();
-		assertEquals(true, rulesDirectory.endsWith("JavaCryptographicArchitecture"));
+		assertEquals(true, rulesDirectory.endsWith("BC"));
 	}
 	
 	// Checks if rules are correctly extracted, when provider is of type `java.security.Provider`,
-	// is given directly, and the rules for that provider do not exist => so it takes Default rules
+	// is given directly, and the rules for that provider exist
 	@Test
 	public void providerDetectionTest6() {
 		ProviderDetection providerDetection = new ProviderDetection();
@@ -91,7 +91,7 @@ public class ProviderDetectionTests {
 		providerDetection.analyze();
 		
 		String rulesDirectory = providerDetection.getRulesDirectory();
-		assertEquals(true, rulesDirectory.endsWith("JavaCryptographicArchitecture"));
+		assertEquals(true, rulesDirectory.endsWith("BC"));
 	}
 	
 	// Checks if provider of type `java.lang.String` is detected when given as a variable
@@ -151,7 +151,7 @@ public class ProviderDetectionTests {
 	}
 	
 	// Checks if rules are correctly extracted, when provider is of type `java.lang.String`,
-	// is given as a variable, and the rules for that provider do not exist => so it takes Default rules
+	// is given as a variable, and the rules for that provider exist
 	@Test
 	public void providerDetectionTest11() {
 		ProviderDetection providerDetection = new ProviderDetection();
@@ -161,11 +161,11 @@ public class ProviderDetectionTests {
 		providerDetection.analyze();
 		
 		String rulesDirectory = providerDetection.getRulesDirectory();
-		assertEquals(true, rulesDirectory.endsWith("JavaCryptographicArchitecture"));
+		assertEquals(true, rulesDirectory.endsWith("BC"));
 	}
 	
 	// Checks if rules are correctly extracted, when provider is of type `java.lang.String`,
-	// is given directly, and the rules for that provider do not exist => so it takes Default rules
+	// is given directly, and the rules for that provider exist
 	@Test
 	public void providerDetectionTest12() {
 		ProviderDetection providerDetection = new ProviderDetection();
@@ -175,7 +175,7 @@ public class ProviderDetectionTests {
 		providerDetection.analyze();
 		
 		String rulesDirectory = providerDetection.getRulesDirectory();
-		assertEquals(true, rulesDirectory.endsWith("JavaCryptographicArchitecture"));
+		assertEquals(true, rulesDirectory.endsWith("BC"));
 	}
 	
 	// Checks if the default ruleset is chosen when provider of type `java.security.Provider`

--- a/CryptoAnalysis/src/test/java/tests/providerdetection/ProviderDetectionTests.java
+++ b/CryptoAnalysis/src/test/java/tests/providerdetection/ProviderDetectionTests.java
@@ -11,7 +11,7 @@ public class ProviderDetectionTests {
 	// Checks if provider of type `java.security.Provider` is detected when given as a variable
 	@Test
 	public void providerDetectionTest1() {
-		ProviderDetection providerDetection = new ProviderDetection();
+		ProviderDetectionTestingFramework providerDetection = new ProviderDetectionTestingFramework();
 		String sootClassPath = providerDetection.getSootClassPath();
 		String mainClass = "tests.providerdetection.ProviderDetectionExample1"; 
 		providerDetection.setupSoot(sootClassPath, mainClass);
@@ -25,7 +25,7 @@ public class ProviderDetectionTests {
 	// Checks if provider of type `java.security.Provider` is detected when given directly
 	@Test
 	public void providerDetectionTest2() {
-		ProviderDetection providerDetection = new ProviderDetection();
+		ProviderDetectionTestingFramework providerDetection = new ProviderDetectionTestingFramework();
 		String sootClassPath = providerDetection.getSootClassPath();
 		String mainClass = "tests.providerdetection.ProviderDetectionExample2"; 
 		providerDetection.setupSoot(sootClassPath, mainClass);
@@ -41,7 +41,7 @@ public class ProviderDetectionTests {
 	// is given as a variable, and the rules for that provider exist
 	@Test
 	public void providerDetectionTest3() {
-		ProviderDetection providerDetection = new ProviderDetection();
+		ProviderDetectionTestingFramework providerDetection = new ProviderDetectionTestingFramework();
 		String sootClassPath = providerDetection.getSootClassPath();
 		String mainClass = "tests.providerdetection.ProviderDetectionExample1"; 
 		providerDetection.setupSoot(sootClassPath, mainClass);
@@ -56,7 +56,7 @@ public class ProviderDetectionTests {
 	// is given directly, and the rules for that provider exist
 	@Test
 	public void providerDetectionTest4() {
-		ProviderDetection providerDetection = new ProviderDetection();
+		ProviderDetectionTestingFramework providerDetection = new ProviderDetectionTestingFramework();
 		String sootClassPath = providerDetection.getSootClassPath();
 		String mainClass = "tests.providerdetection.ProviderDetectionExample2"; 
 		providerDetection.setupSoot(sootClassPath, mainClass);
@@ -70,7 +70,7 @@ public class ProviderDetectionTests {
 	// is given as a variable, and the rules for that provider exist
 	@Test
 	public void providerDetectionTest5() {
-		ProviderDetection providerDetection = new ProviderDetection();
+		ProviderDetectionTestingFramework providerDetection = new ProviderDetectionTestingFramework();
 		String sootClassPath = providerDetection.getSootClassPath();
 		String mainClass = "tests.providerdetection.ProviderDetectionExample3"; 
 		providerDetection.setupSoot(sootClassPath, mainClass);
@@ -84,7 +84,7 @@ public class ProviderDetectionTests {
 	// is given directly, and the rules for that provider exist
 	@Test
 	public void providerDetectionTest6() {
-		ProviderDetection providerDetection = new ProviderDetection();
+		ProviderDetectionTestingFramework providerDetection = new ProviderDetectionTestingFramework();
 		String sootClassPath = providerDetection.getSootClassPath();
 		String mainClass = "tests.providerdetection.ProviderDetectionExample4"; 
 		providerDetection.setupSoot(sootClassPath, mainClass);
@@ -97,7 +97,7 @@ public class ProviderDetectionTests {
 	// Checks if provider of type `java.lang.String` is detected when given as a variable
 	@Test
 	public void providerDetectionTest7() {
-		ProviderDetection providerDetection = new ProviderDetection();
+		ProviderDetectionTestingFramework providerDetection = new ProviderDetectionTestingFramework();
 		String sootClassPath = providerDetection.getSootClassPath();
 		String mainClass = "tests.providerdetection.ProviderDetectionExample5"; 
 		providerDetection.setupSoot(sootClassPath, mainClass);
@@ -111,7 +111,7 @@ public class ProviderDetectionTests {
 	// Checks if provider of type `java.lang.String` is detected when given directly
 	@Test
 	public void providerDetectionTest8() {
-		ProviderDetection providerDetection = new ProviderDetection();
+		ProviderDetectionTestingFramework providerDetection = new ProviderDetectionTestingFramework();
 		String sootClassPath = providerDetection.getSootClassPath();
 		String mainClass = "tests.providerdetection.ProviderDetectionExample6"; 
 		providerDetection.setupSoot(sootClassPath, mainClass);
@@ -126,7 +126,7 @@ public class ProviderDetectionTests {
 	// is given as a variable, and the rules for that provider exist
 	@Test
 	public void providerDetectionTest9() {
-		ProviderDetection providerDetection = new ProviderDetection();
+		ProviderDetectionTestingFramework providerDetection = new ProviderDetectionTestingFramework();
 		String sootClassPath = providerDetection.getSootClassPath();
 		String mainClass = "tests.providerdetection.ProviderDetectionExample5"; 
 		providerDetection.setupSoot(sootClassPath, mainClass);
@@ -140,7 +140,7 @@ public class ProviderDetectionTests {
 	// is given directly, and the rules for that provider exist
 	@Test
 	public void providerDetectionTest10() {
-		ProviderDetection providerDetection = new ProviderDetection();
+		ProviderDetectionTestingFramework providerDetection = new ProviderDetectionTestingFramework();
 		String sootClassPath = providerDetection.getSootClassPath();
 		String mainClass = "tests.providerdetection.ProviderDetectionExample6"; 
 		providerDetection.setupSoot(sootClassPath, mainClass);
@@ -154,7 +154,7 @@ public class ProviderDetectionTests {
 	// is given as a variable, and the rules for that provider exist
 	@Test
 	public void providerDetectionTest11() {
-		ProviderDetection providerDetection = new ProviderDetection();
+		ProviderDetectionTestingFramework providerDetection = new ProviderDetectionTestingFramework();
 		String sootClassPath = providerDetection.getSootClassPath();
 		String mainClass = "tests.providerdetection.ProviderDetectionExample7"; 
 		providerDetection.setupSoot(sootClassPath, mainClass);
@@ -168,7 +168,7 @@ public class ProviderDetectionTests {
 	// is given directly, and the rules for that provider exist
 	@Test
 	public void providerDetectionTest12() {
-		ProviderDetection providerDetection = new ProviderDetection();
+		ProviderDetectionTestingFramework providerDetection = new ProviderDetectionTestingFramework();
 		String sootClassPath = providerDetection.getSootClassPath();
 		String mainClass = "tests.providerdetection.ProviderDetectionExample8"; 
 		providerDetection.setupSoot(sootClassPath, mainClass);
@@ -182,7 +182,7 @@ public class ProviderDetectionTests {
 	// flows through TERNARY operators
 	@Test
 	public void providerDetectionTest13() {
-		ProviderDetection providerDetection = new ProviderDetection();
+		ProviderDetectionTestingFramework providerDetection = new ProviderDetectionTestingFramework();
 		String sootClassPath = providerDetection.getSootClassPath();
 		String mainClass = "tests.providerdetection.ProviderDetectionExample9"; 
 		providerDetection.setupSoot(sootClassPath, mainClass);
@@ -196,7 +196,7 @@ public class ProviderDetectionTests {
 	// flows through IF-ELSE statements
 	@Test
 	public void providerDetectionTest14() {
-		ProviderDetection providerDetection = new ProviderDetection();
+		ProviderDetectionTestingFramework providerDetection = new ProviderDetectionTestingFramework();
 		String sootClassPath = providerDetection.getSootClassPath();
 		String mainClass = "tests.providerdetection.ProviderDetectionExample10"; 
 		providerDetection.setupSoot(sootClassPath, mainClass);
@@ -210,7 +210,7 @@ public class ProviderDetectionTests {
 	// flows through SWITCH statements
 	@Test
 	public void providerDetectionTest15() {
-		ProviderDetection providerDetection = new ProviderDetection();
+		ProviderDetectionTestingFramework providerDetection = new ProviderDetectionTestingFramework();
 		String sootClassPath = providerDetection.getSootClassPath();
 		String mainClass = "tests.providerdetection.ProviderDetectionExample11"; 
 		providerDetection.setupSoot(sootClassPath, mainClass);
@@ -224,7 +224,7 @@ public class ProviderDetectionTests {
 	// flows through TERNARY operators
 	@Test
 	public void providerDetectionTest16() {
-		ProviderDetection providerDetection = new ProviderDetection();
+		ProviderDetectionTestingFramework providerDetection = new ProviderDetectionTestingFramework();
 		String sootClassPath = providerDetection.getSootClassPath();
 		String mainClass = "tests.providerdetection.ProviderDetectionExample12"; 
 		providerDetection.setupSoot(sootClassPath, mainClass);
@@ -238,7 +238,7 @@ public class ProviderDetectionTests {
 	// flows through IF-ELSE statements
 	@Test
 	public void providerDetectionTest17() {
-		ProviderDetection providerDetection = new ProviderDetection();
+		ProviderDetectionTestingFramework providerDetection = new ProviderDetectionTestingFramework();
 		String sootClassPath = providerDetection.getSootClassPath();
 		String mainClass = "tests.providerdetection.ProviderDetectionExample13"; 
 		providerDetection.setupSoot(sootClassPath, mainClass);
@@ -252,7 +252,7 @@ public class ProviderDetectionTests {
 	// flows through SWITCH statements
 	@Test
 	public void providerDetectionTest18() {
-		ProviderDetection providerDetection = new ProviderDetection();
+		ProviderDetectionTestingFramework providerDetection = new ProviderDetectionTestingFramework();
 		String sootClassPath = providerDetection.getSootClassPath();
 		String mainClass = "tests.providerdetection.ProviderDetectionExample14"; 
 		providerDetection.setupSoot(sootClassPath, mainClass);

--- a/CryptoAnalysis/src/test/java/tests/providerdetection/ProviderDetectionTests.java
+++ b/CryptoAnalysis/src/test/java/tests/providerdetection/ProviderDetectionTests.java
@@ -17,7 +17,7 @@ public class ProviderDetectionTests {
 		providerDetection.setupSoot(sootClassPath, mainClass);
 		providerDetection.analyze();
 		
-		String expected = "BC";
+		String expected = "BouncyCastle-JCA";
 		String actual = providerDetection.getProvider();
 		assertEquals(expected, actual);
 	}
@@ -31,7 +31,7 @@ public class ProviderDetectionTests {
 		providerDetection.setupSoot(sootClassPath, mainClass);
 		providerDetection.analyze();
 		
-		String expected = "BC";
+		String expected = "BouncyCastle-JCA";
 		String actual = providerDetection.getProvider();
 		assertEquals(expected, actual);
 	}
@@ -48,7 +48,7 @@ public class ProviderDetectionTests {
 		providerDetection.analyze();
 		
 		String rulesDirectory = providerDetection.getRulesDirectory();
-		assertEquals(true, rulesDirectory.endsWith("BC"));
+		assertEquals(true, rulesDirectory.endsWith("BouncyCastle-JCA"));
 	}
 	
 	
@@ -63,7 +63,7 @@ public class ProviderDetectionTests {
 		providerDetection.analyze();
 		
 		String rulesDirectory = providerDetection.getRulesDirectory();
-		assertEquals(true, rulesDirectory.endsWith("BC"));
+		assertEquals(true, rulesDirectory.endsWith("BouncyCastle-JCA"));
 	}
 	
 	// Checks if rules are correctly extracted, when provider is of type `java.security.Provider`,
@@ -77,7 +77,7 @@ public class ProviderDetectionTests {
 		providerDetection.analyze();
 		
 		String rulesDirectory = providerDetection.getRulesDirectory();
-		assertEquals(true, rulesDirectory.endsWith("BC"));
+		assertEquals(true, rulesDirectory.endsWith("BouncyCastle-JCA"));
 	}
 	
 	// Checks if rules are correctly extracted, when provider is of type `java.security.Provider`,
@@ -91,7 +91,7 @@ public class ProviderDetectionTests {
 		providerDetection.analyze();
 		
 		String rulesDirectory = providerDetection.getRulesDirectory();
-		assertEquals(true, rulesDirectory.endsWith("BC"));
+		assertEquals(true, rulesDirectory.endsWith("BouncyCastle-JCA"));
 	}
 	
 	// Checks if provider of type `java.lang.String` is detected when given as a variable
@@ -103,7 +103,7 @@ public class ProviderDetectionTests {
 		providerDetection.setupSoot(sootClassPath, mainClass);
 		providerDetection.analyze();
 		
-		String expected = "BC";
+		String expected = "BouncyCastle-JCA";
 		String actual = providerDetection.getProvider();
 		assertEquals(expected, actual);
 	}
@@ -117,7 +117,7 @@ public class ProviderDetectionTests {
 		providerDetection.setupSoot(sootClassPath, mainClass);
 		providerDetection.analyze();
 		
-		String expected = "BC";
+		String expected = "BouncyCastle-JCA";
 		String actual = providerDetection.getProvider();
 		assertEquals(expected, actual);
 	}
@@ -133,7 +133,7 @@ public class ProviderDetectionTests {
 		providerDetection.analyze();
 		
 		String rulesDirectory = providerDetection.getRulesDirectory();
-		assertEquals(true, rulesDirectory.endsWith("BC"));
+		assertEquals(true, rulesDirectory.endsWith("BouncyCastle-JCA"));
 	}
 	
 	// Checks if rules are correctly extracted, when provider is of type `java.lang.String`,
@@ -147,7 +147,7 @@ public class ProviderDetectionTests {
 		providerDetection.analyze();
 		
 		String rulesDirectory = providerDetection.getRulesDirectory();
-		assertEquals(true, rulesDirectory.endsWith("BC"));
+		assertEquals(true, rulesDirectory.endsWith("BouncyCastle-JCA"));
 	}
 	
 	// Checks if rules are correctly extracted, when provider is of type `java.lang.String`,
@@ -161,7 +161,7 @@ public class ProviderDetectionTests {
 		providerDetection.analyze();
 		
 		String rulesDirectory = providerDetection.getRulesDirectory();
-		assertEquals(true, rulesDirectory.endsWith("BC"));
+		assertEquals(true, rulesDirectory.endsWith("BouncyCastle-JCA"));
 	}
 	
 	// Checks if rules are correctly extracted, when provider is of type `java.lang.String`,
@@ -175,7 +175,7 @@ public class ProviderDetectionTests {
 		providerDetection.analyze();
 		
 		String rulesDirectory = providerDetection.getRulesDirectory();
-		assertEquals(true, rulesDirectory.endsWith("BC"));
+		assertEquals(true, rulesDirectory.endsWith("BouncyCastle-JCA"));
 	}
 	
 	// Checks if the default ruleset is chosen when provider of type `java.security.Provider`


### PR DESCRIPTION
This PR contains some refactoring and fixes regarding provider detection analysis. The changes in this PR are also used from the provider detection checkbox [PR](https://github.com/eclipse-cognicrypt/CogniCrypt/pull/360) in the CogniCrypt repository. The changes include:

- BouncyCastle-JCA ruleset added in POM file and is downloaded directly from Nexus server
- Refactored the provider detection analysis entry point in HeadessCryptoScanner
- Small fixes regarding NullPointerException error when fetching the CrySL rules
- Refactored ProviderDetection code and removed redundant methods and imports
- Methods from ProviderDetection class that were used for the provider detection JUnit tests, were moved into a newly created class called ProviderDetectionTestingFramework. This is done for having a clearer separation between the provider analysis code and the testing framework
- Refactored ProviderDetectionTests class that contains various JUnit tests