### PR TITLE
Required changes for the CogniCrypt_Fix prototype

### DIFF
--- a/CryptoAnalysis/src/main/java/crypto/analysis/AnalysisSeedWithSpecification.java
+++ b/CryptoAnalysis/src/main/java/crypto/analysis/AnalysisSeedWithSpecification.java
@@ -75,7 +75,7 @@ public class AnalysisSeedWithSpecification extends IAnalysisSeed {
 	private Set<ISLConstraint> missingPredicates = Sets.newHashSet();
 	private ConstraintSolver constraintSolver;
 	private boolean internalConstraintSatisfied;
-	protected Map<Statement, SootMethod> allCallsOnObject = Maps.newHashMap();
+	protected Map<Statement, SootMethod> allCallsOnObject = Maps.newLinkedHashMap();
 	private ExtractParameterAnalysis parameterAnalysis;
 	private Set<ResultsHandler> resultHandlers = Sets.newHashSet();
 	private boolean secure = true;
@@ -642,6 +642,10 @@ public class AnalysisSeedWithSpecification extends IAnalysisSeed {
 	@Override
 	public Set<Node<Statement, Val>> getDataFlowPath() {
 		return results.getDataFlowPath();
+	}
+
+	public Map<Statement, SootMethod> getAllCallsOnObject() {
+		return allCallsOnObject;
 	}
 
 }


### PR DESCRIPTION
This pull requests contains two minimal code changes to the analysis, which are required for the CogniCrypt_Fix prototype 

class AnalysisSeedWithSpecification.java 
- the field Map<Statement, SootMethod> allCallsOnObject = Maps.newLinkedHashMap(); is now a LinkedHashMap instead of HashMap
- add get method for the field allCallsOnObject 

- [x] non-breaking change
