### PR TITLE
Fix various test cases in CryptoAnalysis

### DIFF
--- a/CryptoAnalysis/pom.xml
+++ b/CryptoAnalysis/pom.xml
@@ -104,7 +104,7 @@
 				<artifactId>maven-surefire-plugin</artifactId>
 				<version>2.20</version>
 				<configuration>
-					<argLine>-Xmx16G -Xss128m -Dmaven.home="${maven.home}"</argLine>
+					<argLine>-Xmx8192m -Xss256m -XX:MaxPermSize=2048m -Dmaven.home="${maven.home}"</argLine>
 					<reportsDirectory>../shippable/testresults</reportsDirectory>
 				</configuration>
 				<dependencies>

--- a/CryptoAnalysis/pom.xml
+++ b/CryptoAnalysis/pom.xml
@@ -104,7 +104,7 @@
 				<artifactId>maven-surefire-plugin</artifactId>
 				<version>2.20</version>
 				<configuration>
-					<argLine>-Xmx8192m -Xss256m -XX:MaxPermSize=2048m -Dmaven.home="${maven.home}"</argLine>
+					<argLine>-Xmx12G -Xms256M -Xss256M -XX:MaxPermSize=2G -Dmaven.home="${maven.home}"</argLine>
 					<reportsDirectory>../shippable/testresults</reportsDirectory>
 				</configuration>
 				<dependencies>

--- a/CryptoAnalysis/pom.xml
+++ b/CryptoAnalysis/pom.xml
@@ -55,7 +55,7 @@
 								<artifactItem>
 									<groupId>de.darmstadt.tu.crossing</groupId>
 									<artifactId>JavaCryptographicArchitecture</artifactId>
-									<version>1.4.2</version>
+									<version>1.5.0</version>
 									<classifier>ruleset</classifier>
 									<type>zip</type>
 									<overWrite>true</overWrite>

--- a/CryptoAnalysis/pom.xml
+++ b/CryptoAnalysis/pom.xml
@@ -104,7 +104,7 @@
 				<artifactId>maven-surefire-plugin</artifactId>
 				<version>2.20</version>
 				<configuration>
-					<argLine>-Xmx8G -Xss128m -Dmaven.home="${maven.home}"</argLine>
+					<argLine>-Xmx16G -Xss128m -Dmaven.home="${maven.home}"</argLine>
 					<reportsDirectory>../shippable/testresults</reportsDirectory>
 				</configuration>
 				<dependencies>

--- a/CryptoAnalysis/pom.xml
+++ b/CryptoAnalysis/pom.xml
@@ -106,7 +106,6 @@
 				<configuration>
 					<argLine>-Xmx8192m -Xss256m -XX:MaxPermSize=2048m -Dmaven.home="${maven.home}"</argLine>
 					<reportsDirectory>../shippable/testresults</reportsDirectory>
-					<fork>true</fork>
 				</configuration>
 				<dependencies>
 					<dependency>

--- a/CryptoAnalysis/pom.xml
+++ b/CryptoAnalysis/pom.xml
@@ -104,7 +104,7 @@
 				<artifactId>maven-surefire-plugin</artifactId>
 				<version>2.20</version>
 				<configuration>
-					<argLine>-Xmx12G -Xms256M -Xss256M -XX:MaxPermSize=2G -Dmaven.home="${maven.home}"</argLine>
+					<argLine>-Xmx12G -Xms256M -Dmaven.home="${maven.home}"</argLine>
 					<reportsDirectory>../shippable/testresults</reportsDirectory>
 				</configuration>
 				<dependencies>

--- a/CryptoAnalysis/pom.xml
+++ b/CryptoAnalysis/pom.xml
@@ -106,6 +106,7 @@
 				<configuration>
 					<argLine>-Xmx8192m -Xss256m -XX:MaxPermSize=2048m -Dmaven.home="${maven.home}"</argLine>
 					<reportsDirectory>../shippable/testresults</reportsDirectory>
+					<fork>true</fork>
 				</configuration>
 				<dependencies>
 					<dependency>

--- a/CryptoAnalysis/src/main/java/crypto/constraints/ConstraintSolver.java
+++ b/CryptoAnalysis/src/main/java/crypto/constraints/ConstraintSolver.java
@@ -650,7 +650,7 @@ public class ConstraintSolver {
 		 * @return extracted array values
 		 */
 		protected Map<String, CallSiteWithExtractedValue> extractSootArray(CallSiteWithParamIndex callSite, ExtractedValue allocSite){
-			soot.Value arrayLocal = ((AssignStmt) allocSite.stmt().getUnit().get()).getLeftOp();
+			Value arrayLocal = allocSite.getValue();
 			Body methodBody = allocSite.stmt().getMethod().getActiveBody();
 			Map<String, CallSiteWithExtractedValue> arrVal = Maps.newHashMap();
 				if (methodBody != null) {
@@ -659,8 +659,8 @@ public class ConstraintSolver {
 						final Unit unit = unitIterator.next();
 						if (unit instanceof AssignStmt) {
 							AssignStmt uStmt = (AssignStmt) (unit);
-							soot.Value leftValue = uStmt.getLeftOp();
-							soot.Value rightValue = uStmt.getRightOp();
+							Value leftValue = uStmt.getLeftOp();
+							Value rightValue = uStmt.getRightOp();
 							if (leftValue.toString().contains(arrayLocal.toString()) && !rightValue.toString().contains("newarray")) {
 								arrVal.put(retrieveConstantFromValue(rightValue), new CallSiteWithExtractedValue(callSite, allocSite));
 							}

--- a/CryptoAnalysis/src/test/java/tests/headless/BouncyCastleHeadlessTest.java
+++ b/CryptoAnalysis/src/test/java/tests/headless/BouncyCastleHeadlessTest.java
@@ -105,7 +105,6 @@ public class BouncyCastleHeadlessTest extends AbstractHeadlessTest {
 	}
 	
 	@Test
-	@Ignore
 	public void testBCEllipticCurveExamples() {
 		String mavenProjectPath = new File("../CryptoAnalysisTargets/BCEllipticCurveExamples").getAbsolutePath();
 		MavenProject mavenProject = createAndCompile(mavenProjectPath);

--- a/CryptoAnalysis/src/test/java/tests/headless/BouncyCastleHeadlessTest.java
+++ b/CryptoAnalysis/src/test/java/tests/headless/BouncyCastleHeadlessTest.java
@@ -105,6 +105,7 @@ public class BouncyCastleHeadlessTest extends AbstractHeadlessTest {
 	}
 	
 	@Test
+	@Ignore
 	public void testBCEllipticCurveExamples() {
 		String mavenProjectPath = new File("../CryptoAnalysisTargets/BCEllipticCurveExamples").getAbsolutePath();
 		MavenProject mavenProject = createAndCompile(mavenProjectPath);

--- a/CryptoAnalysis/src/test/java/tests/headless/BragaCryptoTest.java
+++ b/CryptoAnalysis/src/test/java/tests/headless/BragaCryptoTest.java
@@ -362,8 +362,9 @@ public class BragaCryptoTest extends AbstractHeadlessTest {
 		MavenProject mavenProject = createAndCompile(mavenProjectPath);
 		HeadlessCryptoScanner scanner = createScanner(mavenProject);
 		
-		setErrorsCount("<example.NonAuthenticatedEphemeralECDH_192: void main(java.lang.String[])>", ConstraintError.class, 2);
-		setErrorsCount("<example.NonAuthenticatedEphemeralECDH_256: void main(java.lang.String[])>", ConstraintError.class, 2);
+		setErrorsCount("<example.NonAuthenticatedEphemeralECDH_128: void main(java.lang.String[])>", ConstraintError.class, 2);
+		setErrorsCount("<example.NonAuthenticatedEphemeralECDH_192: void main(java.lang.String[])>", ConstraintError.class, 4);
+		setErrorsCount("<example.NonAuthenticatedEphemeralECDH_256: void main(java.lang.String[])>", ConstraintError.class, 4);
 		setErrorsCount("<example.NonAuthenticatedDH_2048: void main(java.lang.String[])>", RequiredPredicateError.class, 2);
 
 		scanner.exec();
@@ -534,28 +535,7 @@ public class BragaCryptoTest extends AbstractHeadlessTest {
 		String mavenProjectPath = new File("../CryptoAnalysisTargets/BragaCryptoBench/cryptogooduses/securecurves").getAbsolutePath();
 		MavenProject mavenProject = createAndCompile(mavenProjectPath);
 		HeadlessCryptoScanner scanner = createScanner(mavenProject);
-		
-		setErrorsCount("<example.SecureCurve_secp224r1: void main(java.lang.String[])>", RequiredPredicateError.class, 1);				
-		setErrorsCount("<example.SecureCurve_secp521r1: void main(java.lang.String[])>", RequiredPredicateError.class, 1);				
-		setErrorsCount("<example.SecureCurve_sect163r1: void main(java.lang.String[])>", RequiredPredicateError.class, 1);				
-		setErrorsCount("<example.SecureCurve_secp192r1: void main(java.lang.String[])>", RequiredPredicateError.class, 1);				
-		setErrorsCount("<example.SecureCurve_sect239k1: void main(java.lang.String[])>", RequiredPredicateError.class, 1);				
-		setErrorsCount("<example.SecureCurve_secp256r1: void main(java.lang.String[])>", RequiredPredicateError.class, 1);				
-		setErrorsCount("<example.SecureCurve_sect233r1: void main(java.lang.String[])>", RequiredPredicateError.class, 1);				
-		setErrorsCount("<example.SecureCurve_sect283r1: void main(java.lang.String[])>", RequiredPredicateError.class, 1);				
-		setErrorsCount("<example.SecureCurve_sect409k1: void main(java.lang.String[])>", RequiredPredicateError.class, 1);				
-		setErrorsCount("<example.SecureCurve_sect163k1: void main(java.lang.String[])>", RequiredPredicateError.class, 1);				
-		setErrorsCount("<example.SecureCurve_secp384r1: void main(java.lang.String[])>", RequiredPredicateError.class, 1);				
-		setErrorsCount("<example.SecureCurve_sect283k1: void main(java.lang.String[])>", RequiredPredicateError.class, 1);				
-		setErrorsCount("<example.SecureCurve_sect571k1: void main(java.lang.String[])>", RequiredPredicateError.class, 1);				
-		setErrorsCount("<example.SecureCurve_sect233k1: void main(java.lang.String[])>", RequiredPredicateError.class, 1);				
-		setErrorsCount("<example.SecureCurve_secp256k1: void main(java.lang.String[])>", RequiredPredicateError.class, 1);				
-		setErrorsCount("<example.SecureCurve_sect409r1: void main(java.lang.String[])>", RequiredPredicateError.class, 1);				
-		setErrorsCount("<example.SecureCurve_sect163r2: void main(java.lang.String[])>", RequiredPredicateError.class, 1);				
-		setErrorsCount("<example.SecureCurve_sect571r1: void main(java.lang.String[])>", RequiredPredicateError.class, 1);				
-		setErrorsCount("<example.SecureCurve_secp192k1: void main(java.lang.String[])>", RequiredPredicateError.class, 1);				
-		setErrorsCount("<example.SecureCurve_secp224k1: void main(java.lang.String[])>", RequiredPredicateError.class, 1);				
-							
+								
 		scanner.exec();
 		assertErrors();
 	}
@@ -903,15 +883,6 @@ public class BragaCryptoTest extends AbstractHeadlessTest {
 		MavenProject mavenProject = createAndCompile(mavenProjectPath);
 		HeadlessCryptoScanner scanner = createScanner(mavenProject);
 		
-		setErrorsCount("<pkc.ecc.insecurecurves.InsecureCurve_sect131r1: void main(java.lang.String[])>", RequiredPredicateError.class, 1);
-		setErrorsCount("<pkc.ecc.insecurecurves.InsecureCurveECDH1: void main(java.lang.String[])>", RequiredPredicateError.class, 1);
-		setErrorsCount("<pkc.ecc.insecurecurves.InsecureCurve_secp160k1: void main(java.lang.String[])>", RequiredPredicateError.class, 1);
-		setErrorsCount("<pkc.ecc.insecurecurves.InsecureCurve_secp112r1: void main(java.lang.String[])>", RequiredPredicateError.class, 1);
-		setErrorsCount("<pkc.ecc.insecurecurves.InsecureCurve_secp128r1: void main(java.lang.String[])>", RequiredPredicateError.class, 1);
-		setErrorsCount("<pkc.ecc.insecurecurves.InsecureCurve_sect113r1: void main(java.lang.String[])>", RequiredPredicateError.class, 1);
-		setErrorsCount("<pkc.ecc.insecurecurves.InsecureCurve_secp160r1: void main(java.lang.String[])>", RequiredPredicateError.class, 1);
-		setErrorsCount("<pkc.ecc.insecurecurves.InsecureCurve_sect193r1: void main(java.lang.String[])>", RequiredPredicateError.class, 1);
-
 		scanner.exec();
 		assertErrors();
 	}
@@ -1017,8 +988,8 @@ public class BragaCryptoTest extends AbstractHeadlessTest {
 		
 		setErrorsCount("<pkc.ka.issuesDHandECDH.NonAuthenticatedEphemeralDH_1024: void main(java.lang.String[])>", ConstraintError.class, 2);
 		setErrorsCount("<pkc.ka.issuesDHandECDH.NonAuthenticatedEphemeralDH_512: void main(java.lang.String[])>", ConstraintError.class, 2);
-		setErrorsCount("<pkc.ka.issuesDHandECDH.NonAuthenticatedEphemeralECDH_112: void main(java.lang.String[])>", ConstraintError.class, 2);
-		setErrorsCount("<pkc.ka.issuesDHandECDH.NonAuthenticatedEphemeralECDH_80: void main(java.lang.String[])>", ConstraintError.class, 2);
+		setErrorsCount("<pkc.ka.issuesDHandECDH.NonAuthenticatedEphemeralECDH_112: void main(java.lang.String[])>", ConstraintError.class, 4);
+		setErrorsCount("<pkc.ka.issuesDHandECDH.NonAuthenticatedEphemeralECDH_80: void main(java.lang.String[])>", ConstraintError.class, 4);
 		setErrorsCount("<pkc.ka.issuesDHandECDH.NonAuthenticatedDH_512: void main(java.lang.String[])>", RequiredPredicateError.class, 2);
 		setErrorsCount("<pkc.ka.issuesDHandECDH.NonAuthenticatedDH_1024: void main(java.lang.String[])>", RequiredPredicateError.class, 2);
 
@@ -1292,19 +1263,17 @@ public class BragaCryptoTest extends AbstractHeadlessTest {
 		MavenProject mavenProject = createAndCompile(mavenProjectPath);
 		HeadlessCryptoScanner scanner = createScanner(mavenProject);
 		
-		setErrorsCount("<pkc.sign.weakSignatureECDSA.RepeatedMessageNonceECDSA_1: void main(java.lang.String[])>", TypestateError.class, 0);
 		setErrorsCount("<pkc.sign.weakSignatureECDSA.RepeatedMessageNonceECDSA_1: void main(java.lang.String[])>", RequiredPredicateError.class, 2);
-		setErrorsCount("<pkc.sign.weakSignatureECDSA.RepeatedMessageNonceECDSA_4: void main(java.lang.String[])>", TypestateError.class, 0);
-		setErrorsCount("<pkc.sign.weakSignatureECDSA.RepeatedMessageNonceECDSA_4: void main(java.lang.String[])>", RequiredPredicateError.class, 5);
+		setErrorsCount("<pkc.sign.weakSignatureECDSA.RepeatedMessageNonceECDSA_2: void main(java.lang.String[])>", RequiredPredicateError.class, 2);
+		setErrorsCount("<pkc.sign.weakSignatureECDSA.RepeatedMessageNonceECDSA_3: void main(java.lang.String[])>", RequiredPredicateError.class, 2);
+		setErrorsCount("<pkc.sign.weakSignatureECDSA.RepeatedMessageNonceECDSA_4: void main(java.lang.String[])>", RequiredPredicateError.class, 2);
 		setErrorsCount("<pkc.sign.weakSignatureECDSA.SUN_80bits_ECDSA112wNONE1: void main(java.lang.String[])>", RequiredPredicateError.class, 2);
 		setErrorsCount("<pkc.sign.weakSignatureECDSA.SUN_80bits_ECDSA112wNONE1: void main(java.lang.String[])>", ConstraintError.class, 5);
 		setErrorsCount("<pkc.sign.weakSignatureECDSA.SUN_80bits_ECDSA112wNONE2: void main(java.lang.String[])>", RequiredPredicateError.class, 2);
 		setErrorsCount("<pkc.sign.weakSignatureECDSA.SUN_80bits_ECDSA112wNONE2: void main(java.lang.String[])>", ConstraintError.class, 3);
 		setErrorsCount("<pkc.sign.weakSignatureECDSA.SUN_80bits_ECDSA112wSHA1: void main(java.lang.String[])>", RequiredPredicateError.class, 2);
 		setErrorsCount("<pkc.sign.weakSignatureECDSA.SUN_80bits_ECDSA112wSHA1: void main(java.lang.String[])>", ConstraintError.class, 3);
-		setErrorsCount("<pkc.sign.weakSignatureECDSA.RepeatedMessageNonceECDSA_2: void main(java.lang.String[])>", RequiredPredicateError.class, 2);
-		setErrorsCount("<pkc.sign.weakSignatureECDSA.RepeatedMessageNonceECDSA_3: void main(java.lang.String[])>", RequiredPredicateError.class, 5);
-
+		
 		scanner.exec();
 		assertErrors();
 	}

--- a/CryptoAnalysis/src/test/java/tests/headless/BragaCryptoTest.java
+++ b/CryptoAnalysis/src/test/java/tests/headless/BragaCryptoTest.java
@@ -1201,6 +1201,7 @@ public class BragaCryptoTest extends AbstractHeadlessTest {
 	// This test case corresponds to the following project in BragaCryptoBench:
 	// https://bitbucket.org/alexmbraga/cryptomisuses/src/master/cai/undefinedCSP/
 	@Test
+	@Ignore
 	public void undefinedCSPExamples() {
 		String mavenProjectPath = new File("../CryptoAnalysisTargets/BragaCryptoBench/cryptomisuses/undefinedCSP").getAbsolutePath();
 		MavenProject mavenProject = createAndCompile(mavenProjectPath);

--- a/CryptoAnalysis/src/test/java/tests/headless/BragaCryptoTest.java
+++ b/CryptoAnalysis/src/test/java/tests/headless/BragaCryptoTest.java
@@ -1,6 +1,8 @@
 package tests.headless;
 
 import java.io.File;
+
+import org.junit.Ignore;
 import org.junit.Test;
 import crypto.HeadlessCryptoScanner;
 import crypto.analysis.errors.ConstraintError;
@@ -1191,6 +1193,7 @@ public class BragaCryptoTest extends AbstractHeadlessTest {
 	// This test case corresponds to the following project in BragaCryptoBench:
 	// https://bitbucket.org/alexmbraga/cryptomisuses/src/master/cai/undefinedCSP/
 	@Test
+	@Ignore
 	public void undefinedCSPExamples() {
 		String mavenProjectPath = new File("../CryptoAnalysisTargets/BragaCryptoBench/cryptomisuses/undefinedCSP").getAbsolutePath();
 		MavenProject mavenProject = createAndCompile(mavenProjectPath);

--- a/CryptoAnalysis/src/test/java/tests/headless/BragaCryptoTest.java
+++ b/CryptoAnalysis/src/test/java/tests/headless/BragaCryptoTest.java
@@ -1201,7 +1201,6 @@ public class BragaCryptoTest extends AbstractHeadlessTest {
 	// This test case corresponds to the following project in BragaCryptoBench:
 	// https://bitbucket.org/alexmbraga/cryptomisuses/src/master/cai/undefinedCSP/
 	@Test
-	@Ignore
 	public void undefinedCSPExamples() {
 		String mavenProjectPath = new File("../CryptoAnalysisTargets/BragaCryptoBench/cryptomisuses/undefinedCSP").getAbsolutePath();
 		MavenProject mavenProject = createAndCompile(mavenProjectPath);

--- a/CryptoAnalysis/src/test/java/tests/headless/BragaCryptoTest.java
+++ b/CryptoAnalysis/src/test/java/tests/headless/BragaCryptoTest.java
@@ -365,10 +365,14 @@ public class BragaCryptoTest extends AbstractHeadlessTest {
 		HeadlessCryptoScanner scanner = createScanner(mavenProject);
 		
 		setErrorsCount("<example.NonAuthenticatedEphemeralECDH_128: void main(java.lang.String[])>", ConstraintError.class, 2);
+		setErrorsCount("<example.NonAuthenticatedEphemeralECDH_128: void main(java.lang.String[])>", RequiredPredicateError.class, 4);
 		setErrorsCount("<example.NonAuthenticatedEphemeralECDH_192: void main(java.lang.String[])>", ConstraintError.class, 4);
+		setErrorsCount("<example.NonAuthenticatedEphemeralECDH_192: void main(java.lang.String[])>", RequiredPredicateError.class, 4);
 		setErrorsCount("<example.NonAuthenticatedEphemeralECDH_256: void main(java.lang.String[])>", ConstraintError.class, 4);
-		setErrorsCount("<example.NonAuthenticatedDH_2048: void main(java.lang.String[])>", RequiredPredicateError.class, 2);
-
+		setErrorsCount("<example.NonAuthenticatedEphemeralECDH_256: void main(java.lang.String[])>", RequiredPredicateError.class, 4);
+		setErrorsCount("<example.NonAuthenticatedDH_2048: void main(java.lang.String[])>", RequiredPredicateError.class, 6);
+		setErrorsCount("<example.NonAuthenticatedEphemeralDH_2048: void main(java.lang.String[])>", RequiredPredicateError.class, 4);
+		
 		scanner.exec();
 		assertErrors();
 	}
@@ -989,11 +993,15 @@ public class BragaCryptoTest extends AbstractHeadlessTest {
 		HeadlessCryptoScanner scanner = createScanner(mavenProject);
 		
 		setErrorsCount("<pkc.ka.issuesDHandECDH.NonAuthenticatedEphemeralDH_1024: void main(java.lang.String[])>", ConstraintError.class, 2);
+		setErrorsCount("<pkc.ka.issuesDHandECDH.NonAuthenticatedEphemeralDH_1024: void main(java.lang.String[])>", RequiredPredicateError.class, 4);
 		setErrorsCount("<pkc.ka.issuesDHandECDH.NonAuthenticatedEphemeralDH_512: void main(java.lang.String[])>", ConstraintError.class, 2);
+		setErrorsCount("<pkc.ka.issuesDHandECDH.NonAuthenticatedEphemeralDH_512: void main(java.lang.String[])>", RequiredPredicateError.class, 4);
 		setErrorsCount("<pkc.ka.issuesDHandECDH.NonAuthenticatedEphemeralECDH_112: void main(java.lang.String[])>", ConstraintError.class, 4);
+		setErrorsCount("<pkc.ka.issuesDHandECDH.NonAuthenticatedEphemeralECDH_112: void main(java.lang.String[])>", RequiredPredicateError.class, 4);
 		setErrorsCount("<pkc.ka.issuesDHandECDH.NonAuthenticatedEphemeralECDH_80: void main(java.lang.String[])>", ConstraintError.class, 4);
-		setErrorsCount("<pkc.ka.issuesDHandECDH.NonAuthenticatedDH_512: void main(java.lang.String[])>", RequiredPredicateError.class, 2);
-		setErrorsCount("<pkc.ka.issuesDHandECDH.NonAuthenticatedDH_1024: void main(java.lang.String[])>", RequiredPredicateError.class, 2);
+		setErrorsCount("<pkc.ka.issuesDHandECDH.NonAuthenticatedEphemeralECDH_80: void main(java.lang.String[])>", RequiredPredicateError.class, 4);
+		setErrorsCount("<pkc.ka.issuesDHandECDH.NonAuthenticatedDH_512: void main(java.lang.String[])>", RequiredPredicateError.class, 6);
+		setErrorsCount("<pkc.ka.issuesDHandECDH.NonAuthenticatedDH_1024: void main(java.lang.String[])>", RequiredPredicateError.class, 6);
 
 		scanner.exec();
 		assertErrors();

--- a/CryptoAnalysis/src/test/java/tests/headless/CogniCryptGeneratedCodeTest.java
+++ b/CryptoAnalysis/src/test/java/tests/headless/CogniCryptGeneratedCodeTest.java
@@ -33,7 +33,10 @@ public class CogniCryptGeneratedCodeTest extends AbstractHeadlessTest {
 
 		//All the following errors are false positives
 		setErrorsCount("<Crypto.PWHasher: java.lang.Boolean verifyPWHash(char[],java.lang.String)>", RequiredPredicateError.class, 2);
-		
+		setErrorsCount("<Crypto.PWHasher: java.lang.Boolean verifyPWHash(char[],java.lang.String)>", HardCodedError.class, 1);
+		setErrorsCount("<Crypto.PWHasher: java.lang.String createPWHash(char[])>", RequiredPredicateError.class, 1);
+		setErrorsCount("<Crypto.PWHasher: java.lang.String createPWHash(char[])>", HardCodedError.class, 1);
+
 		scanner.exec();
 		assertErrors();
 	}

--- a/CryptoAnalysis/src/test/java/tests/headless/CryptoGuardTest.java
+++ b/CryptoAnalysis/src/test/java/tests/headless/CryptoGuardTest.java
@@ -127,7 +127,6 @@ public class CryptoGuardTest extends AbstractHeadlessTest {
 	
 	
 	@Test
-	@Ignore
 	public void pbeIterationExamples() {
 		String mavenProjectPath = new File("../CryptoAnalysisTargets/CryptoGuardExamples/pbeiteration").getAbsolutePath();
 		MavenProject mavenProject = createAndCompile(mavenProjectPath);
@@ -271,7 +270,6 @@ public class CryptoGuardTest extends AbstractHeadlessTest {
 	}
 	
 	@Test
-	@Ignore
 	public void staticSaltsExamples() {
 		String mavenProjectPath = new File("../CryptoAnalysisTargets/CryptoGuardExamples/staticsalts").getAbsolutePath();
 		MavenProject mavenProject = createAndCompile(mavenProjectPath);

--- a/CryptoAnalysis/src/test/java/tests/headless/CryptoGuardTest.java
+++ b/CryptoAnalysis/src/test/java/tests/headless/CryptoGuardTest.java
@@ -193,6 +193,7 @@ public class CryptoGuardTest extends AbstractHeadlessTest {
 		
 		// This test case corresponds to the following project in CryptoGuard:
 		// https://github.com/CryptoGuardOSS/cryptoapi-bench/blob/master/src/main/java/org/cryptoapi/bench/predictablekeystorepassword/PredictableKeyStorePasswordABICase1.java
+		setErrorsCount("<example.predictablekeystorepassword.PredictableKeyStorePasswordABICase1: void go(java.lang.String)>", HardCodedError.class, 1);	
 		setErrorsCount("<example.predictablekeystorepassword.PredictableKeyStorePasswordABICase1: void go(java.lang.String)>", NeverTypeOfError.class, 1);	
 		// ABH1, ABI2, BB1 are other similar test cases that were not included
 		
@@ -213,11 +214,13 @@ public class CryptoGuardTest extends AbstractHeadlessTest {
 		// This test case corresponds to the following project in CryptoGuard:
 		// https://github.com/CryptoGuardOSS/cryptoapi-bench/blob/master/src/main/java/org/cryptoapi/bench/predictablepbepassword/PredictablePBEPasswordABHCase2.java
 		setErrorsCount("<example.predictablepbepassword.PredictablePBEPasswordABHCase2: void key(java.lang.String)>", NeverTypeOfError.class, 1);	
+		setErrorsCount("<example.predictablepbepassword.PredictablePBEPasswordABHCase2: void key(java.lang.String)>", HardCodedError.class, 1);	
 		setErrorsCount("<example.predictablepbepassword.PredictablePBEPasswordABHCase2: void main(java.lang.String[])>", IncompleteOperationError.class, 1);
-		
+
 		// This test case corresponds to the following project in CryptoGuard:
 		// https://github.com/CryptoGuardOSS/cryptoapi-bench/blob/master/src/main/java/org/cryptoapi/bench/predictablepbepassword/PredictablePBEPasswordABICase1.java
 		setErrorsCount("<example.predictablepbepassword.PredictablePBEPasswordABICase1: void key(java.lang.String)>", NeverTypeOfError.class, 1);	
+		setErrorsCount("<example.predictablepbepassword.PredictablePBEPasswordABICase1: void key(java.lang.String)>", HardCodedError.class, 1);	
 		setErrorsCount("<example.predictablepbepassword.PredictablePBEPasswordABICase1: void main(java.lang.String[])>", IncompleteOperationError.class, 1);
 		// ABHCase1, BBCase1 are similar to the case above
 		

--- a/CryptoAnalysis/src/test/java/tests/headless/CryptoGuardTest.java
+++ b/CryptoAnalysis/src/test/java/tests/headless/CryptoGuardTest.java
@@ -127,6 +127,7 @@ public class CryptoGuardTest extends AbstractHeadlessTest {
 	
 	
 	@Test
+	@Ignore
 	public void pbeIterationExamples() {
 		String mavenProjectPath = new File("../CryptoAnalysisTargets/CryptoGuardExamples/pbeiteration").getAbsolutePath();
 		MavenProject mavenProject = createAndCompile(mavenProjectPath);
@@ -270,6 +271,7 @@ public class CryptoGuardTest extends AbstractHeadlessTest {
 	}
 	
 	@Test
+	@Ignore
 	public void staticSaltsExamples() {
 		String mavenProjectPath = new File("../CryptoAnalysisTargets/CryptoGuardExamples/staticsalts").getAbsolutePath();
 		MavenProject mavenProject = createAndCompile(mavenProjectPath);

--- a/CryptoAnalysis/src/test/java/tests/headless/CryptoGuardTest.java
+++ b/CryptoAnalysis/src/test/java/tests/headless/CryptoGuardTest.java
@@ -38,15 +38,18 @@ public class CryptoGuardTest extends AbstractHeadlessTest {
 		// https://github.com/CryptoGuardOSS/cryptoapi-bench/blob/master/src/main/java/org/cryptoapi/bench/brokencrypto/BrokenCryptoABICase1.java
 		setErrorsCount("<example.brokencrypto.BrokenCryptoABICase1: void doCrypto(java.lang.String)>", ConstraintError.class, 1);
 		setErrorsCount("<example.brokencrypto.BrokenCryptoABICase1: void doCrypto(java.lang.String)>", IncompleteOperationError.class, 1);
-		
+		setErrorsCount("<example.brokencrypto.BrokenCryptoABICase1: void doCrypto(java.lang.String)>", RequiredPredicateError.class, 1);
+
 		// This test case corresponds to the following project in CryptoGuard:
 		// https://github.com/CryptoGuardOSS/cryptoapi-bench/blob/master/src/main/java/org/cryptoapi/bench/brokencrypto/BrokenCryptoABICase2.java
 		setErrorsCount("<example.brokencrypto.BrokenCryptoABICase2: void doCrypto(java.lang.String)>", ConstraintError.class, 2);
+		setErrorsCount("<example.brokencrypto.BrokenCryptoABICase2: void doCrypto(java.lang.String)>", RequiredPredicateError.class, 1);
 		setErrorsCount("<example.brokencrypto.BrokenCryptoABICase2: void doCrypto(java.lang.String)>", IncompleteOperationError.class, 1);
 		// ABICase3, ABICase4, ABICase9 not included as tests due to being similar to ABICase1 and ABICase2 above
 		
 		// This test case corresponds to the following project in CryptoGuard:
 		// https://github.com/CryptoGuardOSS/cryptoapi-bench/blob/master/src/main/java/org/cryptoapi/bench/brokencrypto/BrokenCryptoABICase5.java
+		setErrorsCount("<example.brokencrypto.BrokenCryptoABICase5: void doCrypto()>", RequiredPredicateError.class, 1);
 		setErrorsCount("<example.brokencrypto.BrokenCryptoABICase5: void doCrypto()>", IncompleteOperationError.class, 1);
 		setErrorsCount(ConstraintError.class, new TruePositives(1), new FalseNegatives(1, "ConstraintError not caught! //Related to https://github.com/CROSSINGTUD/CryptoAnalysis/issues/163"), "<example.brokencrypto.BrokenCryptoABICase5: void doCrypto()>");
 		// ABICase6, -7, -8, -10 not included as tests due to being similar to ABICase5 above
@@ -54,6 +57,7 @@ public class CryptoGuardTest extends AbstractHeadlessTest {
 		// This test case corresponds to the following project in CryptoGuard:
 		// https://github.com/CryptoGuardOSS/cryptoapi-bench/blob/master/src/main/java/org/cryptoapi/bench/brokencrypto/BrokenCryptoBBCase3.java
 		setErrorsCount("<example.brokencrypto.BrokenCryptoBBCase3: void go()>", ConstraintError.class, 2);
+		setErrorsCount("<example.brokencrypto.BrokenCryptoBBCase3: void go()>", RequiredPredicateError.class, 1);
 		setErrorsCount("<example.brokencrypto.BrokenCryptoBBCase3: void go()>", IncompleteOperationError.class, 1);
 		// BBCase1, BBCase2, BBCase4, BBCase5 not included as tests due to being similar to BBCase3 above
 		
@@ -100,10 +104,12 @@ public class CryptoGuardTest extends AbstractHeadlessTest {
 		// https://github.com/CryptoGuardOSS/cryptoapi-bench/blob/master/src/main/java/org/cryptoapi/bench/insecureasymmetriccrypto/InsecureAsymmetricCipherABICase1.java
 		setErrorsCount("<example.insecureasymmetriccrypto.InsecureAsymmetricCipherABICase1: void go(java.security.KeyPairGenerator,java.security.KeyPair)>", IncompleteOperationError.class, 2);
 		setErrorsCount("<example.insecureasymmetriccrypto.InsecureAsymmetricCipherABICase1: void main(java.lang.String[])>", TypestateError.class, 1);
-		
+		setErrorsCount("<example.insecureasymmetriccrypto.InsecureAsymmetricCipherABICase1: void go(java.security.KeyPairGenerator,java.security.KeyPair)>", RequiredPredicateError.class, 2);
+
 		// This test case corresponds to the following project in CryptoGuard:
 		// https://github.com/CryptoGuardOSS/cryptoapi-bench/blob/master/src/main/java/org/cryptoapi/bench/insecureasymmetriccrypto/InsecureAsymmetricCipherABICase2.java
 		setErrorsCount("<example.insecureasymmetriccrypto.InsecureAsymmetricCipherABICase2: void go(java.security.KeyPairGenerator,java.security.KeyPair)>", IncompleteOperationError.class, 2);
+		setErrorsCount("<example.insecureasymmetriccrypto.InsecureAsymmetricCipherABICase2: void go(java.security.KeyPairGenerator,java.security.KeyPair)>", RequiredPredicateError.class, 2);
 		setErrorsCount("<example.insecureasymmetriccrypto.InsecureAsymmetricCipherABICase2: void main(java.lang.String[])>", ConstraintError.class, 1);
 		// In the case above, misuse is caught correctly, but the keysize is reported to be 0
 		// and not 1024, as it really is. This is caused because of the structure of the project
@@ -113,7 +119,8 @@ public class CryptoGuardTest extends AbstractHeadlessTest {
 		// https://github.com/CryptoGuardOSS/cryptoapi-bench/blob/master/src/main/java/org/cryptoapi/bench/insecureasymmetriccrypto/InsecureAsymmetricCipherBB Case1.java
 		setErrorsCount("<example.insecureasymmetriccrypto.InsecureAsymmetricCipherBBCase1: void go()>", IncompleteOperationError.class, 2);
 		setErrorsCount("<example.insecureasymmetriccrypto.InsecureAsymmetricCipherBBCase1: void go()>", ConstraintError.class, 1);
-				
+		setErrorsCount("<example.insecureasymmetriccrypto.InsecureAsymmetricCipherBBCase1: void go()>", RequiredPredicateError.class, 2);
+		
 		scanner.exec();
 		assertErrors();
 	}
@@ -234,26 +241,28 @@ public class CryptoGuardTest extends AbstractHeadlessTest {
 		// This test case corresponds to the following project in CryptoGuard:
 		// https://github.com/CryptoGuardOSS/cryptoapi-bench/blob/master/src/main/java/org/cryptoapi/bench/staticinitializationvector/StaticInitializationVectorABHCase1.java
 		setErrorsCount("<example.staticinitializationvector.StaticInitializationVectorABHCase1: void go()>", IncompleteOperationError.class, 1);
-		setErrorsCount("<example.staticinitializationvector.StaticInitializationVectorABHCase1: void go()>", RequiredPredicateError.class, 1);
+		setErrorsCount("<example.staticinitializationvector.StaticInitializationVectorABHCase1: void go()>", RequiredPredicateError.class, 2);
 		
 		// This test case corresponds to the following project in CryptoGuard:
 		// https://github.com/CryptoGuardOSS/cryptoapi-bench/blob/master/src/main/java/org/cryptoapi/bench/staticinitializationvector/StaticInitializationVectorABHCase2.java
 		setErrorsCount("<example.staticinitializationvector.StaticInitializationVectorABHCase2: void go()>", IncompleteOperationError.class, 1);
-		setErrorsCount("<example.staticinitializationvector.StaticInitializationVectorABHCase2: void go()>", RequiredPredicateError.class, 1);
+		setErrorsCount("<example.staticinitializationvector.StaticInitializationVectorABHCase2: void go()>", RequiredPredicateError.class, 2);
 		
 		// This test case corresponds to the following project in CryptoGuard:
 		// https://github.com/CryptoGuardOSS/cryptoapi-bench/blob/master/src/main/java/org/cryptoapi/bench/staticinitializationvector/StaticInitializationVectorABICase1.java
 		setErrorsCount("<example.staticinitializationvector.StaticInitializationVectorABICase1: void go(javax.crypto.spec.IvParameterSpec)>", IncompleteOperationError.class, 1);
+		setErrorsCount("<example.staticinitializationvector.StaticInitializationVectorABICase1: void go(javax.crypto.spec.IvParameterSpec)>", RequiredPredicateError.class, 1);
 		setErrorsCount("<example.staticinitializationvector.StaticInitializationVectorABICase1: void main(java.lang.String[])>", RequiredPredicateError.class, 1);
 		
 		// This test case corresponds to the following project in CryptoGuard:
 		// https://github.com/CryptoGuardOSS/cryptoapi-bench/blob/master/src/main/java/org/cryptoapi/bench/staticinitializationvector/StaticInitializationVectorABICase2.java
 		setErrorsCount("<example.staticinitializationvector.StaticInitializationVectorABICase2: void go(javax.crypto.spec.IvParameterSpec)>", IncompleteOperationError.class, 1);
+		setErrorsCount("<example.staticinitializationvector.StaticInitializationVectorABICase2: void go(javax.crypto.spec.IvParameterSpec)>", RequiredPredicateError.class, 1);
 		setErrorsCount("<example.staticinitializationvector.StaticInitializationVectorABICase2: void main(java.lang.String[])>", RequiredPredicateError.class, 1);
 		
 		// This test case corresponds to the following project in CryptoGuard:
 		// https://github.com/CryptoGuardOSS/cryptoapi-bench/blob/master/src/main/java/org/cryptoapi/bench/staticinitializationvector/StaticInitializationVectorBBCase1.java
-		setErrorsCount("<example.staticinitializationvector.StaticInitializationVectorBBCase1: void go()>", RequiredPredicateError.class, 1);
+		setErrorsCount("<example.staticinitializationvector.StaticInitializationVectorBBCase1: void go()>", RequiredPredicateError.class, 2);
 		setErrorsCount("<example.staticinitializationvector.StaticInitializationVectorBBCase1: void go()>", IncompleteOperationError.class, 1);
 			
 		scanner.exec();

--- a/CryptoAnalysis/src/test/java/tests/headless/MessageDigestExampleTest.java
+++ b/CryptoAnalysis/src/test/java/tests/headless/MessageDigestExampleTest.java
@@ -16,7 +16,7 @@ public class MessageDigestExampleTest extends AbstractHeadlessTest{
 		HeadlessCryptoScanner scanner = createScanner(mavenProject);
 		
 		//false positive
-		setErrorsCount("<MessageDigestExample.MessageDigestExample.Main: java.lang.String getSHA256(java.io.InputStream)>", IncompleteOperationError.class, 1);
+		setErrorsCount("<MessageDigestExample.MessageDigestExample.Main: java.lang.String getSHA256(java.io.InputStream)>", IncompleteOperationError.class, 2);
 		
 		scanner.exec();
 		assertErrors();

--- a/CryptoAnalysis/src/test/java/tests/headless/ReportedIssueTest.java
+++ b/CryptoAnalysis/src/test/java/tests/headless/ReportedIssueTest.java
@@ -27,9 +27,11 @@ public class ReportedIssueTest extends AbstractHeadlessTest {
 		setErrorsCount("<issue81.Encryption: javax.crypto.SecretKey generateKey(java.lang.String)>", RequiredPredicateError.class, 3);
 		setErrorsCount("<issue81.Encryption: javax.crypto.SecretKey generateKey(java.lang.String)>", NeverTypeOfError.class, 1);
 		setErrorsCount("<issue81.Encryption: javax.crypto.SecretKey generateKey(java.lang.String)>", ConstraintError.class, 1);
+		setErrorsCount("<issue81.Encryption: javax.crypto.SecretKey generateKey(java.lang.String)>", HardCodedError.class, 1);
 
 		setErrorsCount("<issue81.Main: void main(java.lang.String[])>", IncompleteOperationError.class, 1);
 		setErrorsCount("<issue81.Main: void main(java.lang.String[])>", NeverTypeOfError.class, 1);
+		setErrorsCount("<issue81.Main: void main(java.lang.String[])>", HardCodedError.class, 1);
 
 		setErrorsCount("<issuecognicrypt210.CogniCryptSecretKeySpec: void main(java.lang.String[])>", ConstraintError.class, 0);
 		setErrorsCount("<issuecognicrypt210.CogniCryptSecretKeySpec: void main(java.lang.String[])>", RequiredPredicateError.class, 2);
@@ -43,6 +45,7 @@ public class ReportedIssueTest extends AbstractHeadlessTest {
 		setErrorsCount("<issue68.AESCryptor: byte[] getKey(java.lang.String)>", NeverTypeOfError.class, 1);
 		setErrorsCount("<issue68.AESCryptor: byte[] getKey(java.lang.String)>", RequiredPredicateError.class, 2);
 		setErrorsCount("<issue68.AESCryptor: byte[] getKey(java.lang.String)>", IncompleteOperationError.class, 1);
+		setErrorsCount("<issue68.AESCryptor: byte[] getKey(java.lang.String)>", HardCodedError.class, 1);
 		setErrorsCount("<issue68.AESCryptor: javax.crypto.SecretKeyFactory getFactory()>", ConstraintError.class, 1);
 		setErrorsCount("<issue68.AESCryptor: byte[] encryptImpl(byte[])>", RequiredPredicateError.class, 1);
 

--- a/CryptoAnalysis/src/test/java/tests/headless/StaticAnalysisDemoTest.java
+++ b/CryptoAnalysis/src/test/java/tests/headless/StaticAnalysisDemoTest.java
@@ -6,6 +6,7 @@ import org.junit.Test;
 
 import crypto.HeadlessCryptoScanner;
 import crypto.analysis.errors.ConstraintError;
+import crypto.analysis.errors.HardCodedError;
 import crypto.analysis.errors.IncompleteOperationError;
 import crypto.analysis.errors.NeverTypeOfError;
 import crypto.analysis.errors.RequiredPredicateError;
@@ -73,6 +74,7 @@ public class StaticAnalysisDemoTest extends AbstractHeadlessTest {
 		
 		setErrorsCount("<org.glassfish.grizzly.config.ssl.CustomClass: void init(javax.crypto.SecretKey,java.lang.String)>", ConstraintError.class, 1);
 		setErrorsCount("<org.glassfish.grizzly.config.ssl.JSSESocketFactory: java.security.KeyStore getStore(java.lang.String,java.lang.String,java.lang.String)>", NeverTypeOfError.class, 1);
+		setErrorsCount("<org.glassfish.grizzly.config.ssl.JSSESocketFactory: java.security.KeyStore getStore(java.lang.String,java.lang.String,java.lang.String)>", HardCodedError.class, 1);
 
 		scanner.exec();
 		assertErrors();
@@ -91,6 +93,7 @@ public class StaticAnalysisDemoTest extends AbstractHeadlessTest {
 		setErrorsCount("<main.Main: void main(java.lang.String[])>", RequiredPredicateError.class, 3);
 		setErrorsCount("<main.Main: void keyStoreExample()>", ConstraintError.class, 1);
 		setErrorsCount("<main.Main: void keyStoreExample()>", NeverTypeOfError.class, 1);
+		setErrorsCount("<main.Main: void keyStoreExample()>", HardCodedError.class, 1);
 		setErrorsCount("<main.Main: void cipherUsageExample()>", ConstraintError.class, 1);
 
 		setErrorsCount("<main.Main: void use(javax.crypto.Cipher)>", TypestateError.class, 1);
@@ -122,16 +125,6 @@ public class StaticAnalysisDemoTest extends AbstractHeadlessTest {
 		String mavenProjectPath = new File("../CryptoAnalysisTargets/SSLMisuseExample").getAbsolutePath();
 		MavenProject mavenProject = createAndCompile(mavenProjectPath);
 		HeadlessCryptoScanner scanner = createScanner(mavenProject);
-		
-		setErrorsCount(new ErrorSpecification.Builder("<crypto.SSLExample: void MisuseOne()>")
-				.withTPs(ConstraintError.class, 1)
-				.build());
-		setErrorsCount(new ErrorSpecification.Builder("<crypto.SSLExample: void MisuseTwo()>")
-				.withTPs(ConstraintError.class, 1)
-				.build());
-		setErrorsCount(new ErrorSpecification.Builder("<crypto.SSLExample: void MisuseThree()>")
-				.withTPs(ConstraintError.class, 2)
-				.build());
 		
 		scanner.exec();
 		assertErrors();

--- a/CryptoAnalysis/src/test/java/tests/headless/StaticAnalysisDemoTest.java
+++ b/CryptoAnalysis/src/test/java/tests/headless/StaticAnalysisDemoTest.java
@@ -88,7 +88,8 @@ public class StaticAnalysisDemoTest extends AbstractHeadlessTest {
 //
 		setErrorsCount("<main.Main: void main(java.lang.String[])>", ConstraintError.class, 1);
 		setErrorsCount("<main.Main: void main(java.lang.String[])>", TypestateError.class, 1);
-		setErrorsCount("<main.Main: void main(java.lang.String[])>", RequiredPredicateError.class, 1);
+		setErrorsCount("<main.Main: void main(java.lang.String[])>", RequiredPredicateError.class, 3);
+		setErrorsCount("<main.Main: void keyStoreExample()>", ConstraintError.class, 1);
 		setErrorsCount("<main.Main: void keyStoreExample()>", NeverTypeOfError.class, 1);
 		setErrorsCount("<main.Main: void cipherUsageExample()>", ConstraintError.class, 1);
 

--- a/CryptoAnalysis/src/test/java/tests/pattern/BouncyCastlesUsagePatternTest.java
+++ b/CryptoAnalysis/src/test/java/tests/pattern/BouncyCastlesUsagePatternTest.java
@@ -49,7 +49,9 @@ public class BouncyCastlesUsagePatternTest extends UsagePatternTestingFramework 
         Assertions.mustNotBeInAcceptingState(eng);
 	}
 	
+	
 	@Test
+	@Ignore
 	public void rsKeyParameters() {
 		BigInteger mod = new BigInteger("a0b8e8321b041acd40b7", 16);
 		BigInteger pub = new BigInteger("9f0783a49...da", 16);	

--- a/CryptoAnalysis/src/test/java/tests/pattern/BouncyCastlesUsagePatternTest.java
+++ b/CryptoAnalysis/src/test/java/tests/pattern/BouncyCastlesUsagePatternTest.java
@@ -51,7 +51,6 @@ public class BouncyCastlesUsagePatternTest extends UsagePatternTestingFramework 
 	
 	
 	@Test
-	@Ignore
 	public void rsKeyParameters() {
 		BigInteger mod = new BigInteger("a0b8e8321b041acd40b7", 16);
 		BigInteger pub = new BigInteger("9f0783a49...da", 16);	

--- a/CryptoAnalysis/src/test/java/tests/pattern/CipherDigestIOStreamTest.java
+++ b/CryptoAnalysis/src/test/java/tests/pattern/CipherDigestIOStreamTest.java
@@ -39,6 +39,7 @@ public class CipherDigestIOStreamTest extends UsagePatternTestingFramework{
 	  while (dis.read() != -1) {
 
 	  }
+	  dis.close();
 	  Assertions.mustBeInAcceptingState(dis);
 	}
 	
@@ -51,6 +52,7 @@ public class CipherDigestIOStreamTest extends UsagePatternTestingFramework{
 	  Assertions.extValue(0);
 	  Assertions.extValue(1);
 	  dis.read("input".getBytes(), 0, "input".getBytes().length);
+	  dis.close();
 	  Assertions.mustBeInAcceptingState(dis);
 	}
 
@@ -117,6 +119,7 @@ public class CipherDigestIOStreamTest extends UsagePatternTestingFramework{
 	  Assertions.extValue(0);
 	  Assertions.extValue(1);
 	  dos.write("message".getBytes(), 0, "message".getBytes().length);
+	  dos.close();
 	  Assertions.mustBeInAcceptingState(dos);
 	}
 

--- a/CryptoAnalysis/src/test/java/tests/pattern/UsagePatternTest.java
+++ b/CryptoAnalysis/src/test/java/tests/pattern/UsagePatternTest.java
@@ -733,7 +733,6 @@ public class UsagePatternTest extends UsagePatternTestingFramework {
 	}
 
 	@Test
-	@Ignore
 	public void UsagePatternMinPBEIterations() throws GeneralSecurityException, IOException {
 		final byte[] salt = new byte[32];
 		SecureRandom.getInstanceStrong().nextBytes(salt);

--- a/CryptoAnalysis/src/test/java/tests/pattern/UsagePatternTest.java
+++ b/CryptoAnalysis/src/test/java/tests/pattern/UsagePatternTest.java
@@ -32,6 +32,8 @@ import javax.crypto.spec.PBEKeySpec;
 import javax.crypto.spec.PBEParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 import javax.security.auth.DestroyFailedException;
+
+import org.junit.Ignore;
 import org.junit.Test;
 import crypto.analysis.CrySLRulesetSelector.Ruleset;
 import test.UsagePatternTestingFramework;
@@ -731,6 +733,7 @@ public class UsagePatternTest extends UsagePatternTestingFramework {
 	}
 
 	@Test
+	@Ignore
 	public void UsagePatternMinPBEIterations() throws GeneralSecurityException, IOException {
 		final byte[] salt = new byte[32];
 		SecureRandom.getInstanceStrong().nextBytes(salt);

--- a/CryptoAnalysis/src/test/java/tests/pattern/tink/TestDigitalSignature.java
+++ b/CryptoAnalysis/src/test/java/tests/pattern/tink/TestDigitalSignature.java
@@ -19,6 +19,7 @@ import com.google.crypto.tink.signature.SignatureKeyTemplates;
 import crypto.analysis.CrySLRulesetSelector.Ruleset;
 import test.assertions.Assertions;
 
+@SuppressWarnings("deprecation")
 @Ignore
 public class TestDigitalSignature extends TestTinkPrimitives {
 
@@ -28,7 +29,7 @@ public class TestDigitalSignature extends TestTinkPrimitives {
 	}
 	@Test
 	public void generateNewECDSA_P256() throws GeneralSecurityException {
-		KeyTemplate kt = SignatureKeyTemplates.createEcdsaKeyTemplate(HashType.SHA256, EllipticCurveType.NIST_P256, EcdsaSignatureEncoding.DER);;
+		KeyTemplate kt = SignatureKeyTemplates.createEcdsaKeyTemplate(HashType.SHA256, EllipticCurveType.NIST_P256, EcdsaSignatureEncoding.DER, null);
 		KeysetHandle ksh = KeysetHandle.generateNew(kt);
 		Assertions.mustBeInAcceptingState(kt);
 		Assertions.mustBeInAcceptingState(ksh);
@@ -36,7 +37,7 @@ public class TestDigitalSignature extends TestTinkPrimitives {
 	
 	@Test
 	public void generateNewECDSA_P384() throws GeneralSecurityException {
-		KeyTemplate kt = SignatureKeyTemplates.createEcdsaKeyTemplate(HashType.SHA512, EllipticCurveType.NIST_P384, EcdsaSignatureEncoding.DER);
+		KeyTemplate kt = SignatureKeyTemplates.createEcdsaKeyTemplate(HashType.SHA512, EllipticCurveType.NIST_P384, EcdsaSignatureEncoding.DER, null);
 		KeysetHandle ksh = KeysetHandle.generateNew(kt);
 		Assertions.mustBeInAcceptingState(kt);
 		Assertions.mustBeInAcceptingState(ksh);
@@ -44,7 +45,7 @@ public class TestDigitalSignature extends TestTinkPrimitives {
 	
 	@Test
 	public void generateNewECDSA_P521() throws GeneralSecurityException {
-		KeyTemplate kt = SignatureKeyTemplates.createEcdsaKeyTemplate(HashType.SHA512, EllipticCurveType.NIST_P521, EcdsaSignatureEncoding.DER);
+		KeyTemplate kt = SignatureKeyTemplates.createEcdsaKeyTemplate(HashType.SHA512, EllipticCurveType.NIST_P521, EcdsaSignatureEncoding.DER, null);
 		KeysetHandle ksh = KeysetHandle.generateNew(kt);
 		Assertions.mustBeInAcceptingState(kt);
 		Assertions.mustBeInAcceptingState(ksh);
@@ -52,7 +53,7 @@ public class TestDigitalSignature extends TestTinkPrimitives {
 	
 	@Test
 	public void generateNewECDSA_P256_IEEE_P1363() throws GeneralSecurityException {
-		KeyTemplate kt = SignatureKeyTemplates.createEcdsaKeyTemplate(HashType.SHA256, EllipticCurveType.NIST_P256, EcdsaSignatureEncoding.IEEE_P1363);
+		KeyTemplate kt = SignatureKeyTemplates.createEcdsaKeyTemplate(HashType.SHA256, EllipticCurveType.NIST_P256, EcdsaSignatureEncoding.IEEE_P1363, null);
 		KeysetHandle ksh = KeysetHandle.generateNew(kt);
 		Assertions.mustBeInAcceptingState(kt);
 		Assertions.mustBeInAcceptingState(ksh);
@@ -60,7 +61,7 @@ public class TestDigitalSignature extends TestTinkPrimitives {
 	
 	@Test
 	public void generateNewECDSA_P384_IEEE_P1363() throws GeneralSecurityException {
-		KeyTemplate kt = SignatureKeyTemplates.createEcdsaKeyTemplate(HashType.SHA512, EllipticCurveType.NIST_P384, EcdsaSignatureEncoding.IEEE_P1363);
+		KeyTemplate kt = SignatureKeyTemplates.createEcdsaKeyTemplate(HashType.SHA512, EllipticCurveType.NIST_P384, EcdsaSignatureEncoding.IEEE_P1363, null);
 		KeysetHandle ksh = KeysetHandle.generateNew(kt);
 		Assertions.mustBeInAcceptingState(kt);
 		Assertions.mustBeInAcceptingState(ksh);
@@ -68,7 +69,7 @@ public class TestDigitalSignature extends TestTinkPrimitives {
 	
 	@Test
 	public void generateNewECDSA_P521_IEEE_P1363() throws GeneralSecurityException {
-		KeyTemplate kt = SignatureKeyTemplates.createEcdsaKeyTemplate(HashType.SHA512, EllipticCurveType.NIST_P521, EcdsaSignatureEncoding.IEEE_P1363);
+		KeyTemplate kt = SignatureKeyTemplates.createEcdsaKeyTemplate(HashType.SHA512, EllipticCurveType.NIST_P521, EcdsaSignatureEncoding.IEEE_P1363, null);
 		KeysetHandle ksh = KeysetHandle.generateNew(kt);
 		Assertions.mustBeInAcceptingState(kt);
 		Assertions.mustBeInAcceptingState(ksh);
@@ -76,12 +77,13 @@ public class TestDigitalSignature extends TestTinkPrimitives {
 	
 	@Test
 	public void signUsingECDSA_P256() throws GeneralSecurityException {
-		KeyTemplate kt = SignatureKeyTemplates.createEcdsaKeyTemplate(HashType.SHA256, EllipticCurveType.NIST_P256, EcdsaSignatureEncoding.DER);;
+		KeyTemplate kt = SignatureKeyTemplates.createEcdsaKeyTemplate(HashType.SHA256, EllipticCurveType.NIST_P256, EcdsaSignatureEncoding.DER, null);;
 		KeysetHandle ksh = KeysetHandle.generateNew(kt);
 		
 		Assertions.mustBeInAcceptingState(kt);
 		Assertions.mustBeInAcceptingState(ksh);
 		
+		@SuppressWarnings("deprecation")
 		PublicKeySign pks = PublicKeySignFactory.getPrimitive(ksh);
 		
 		pks.sign("this is just a test using digital signatures using Google Tink".getBytes());
@@ -92,12 +94,13 @@ public class TestDigitalSignature extends TestTinkPrimitives {
 	
 	@Test
 	public void signAndVerifyUsingECDSA_P256() throws GeneralSecurityException {
-		KeyTemplate kt = SignatureKeyTemplates.createEcdsaKeyTemplate(HashType.SHA256, EllipticCurveType.NIST_P256, EcdsaSignatureEncoding.DER);;
+		KeyTemplate kt = SignatureKeyTemplates.createEcdsaKeyTemplate(HashType.SHA256, EllipticCurveType.NIST_P256, EcdsaSignatureEncoding.DER, null);;
 		KeysetHandle ksh = KeysetHandle.generateNew(kt);
 		
 		Assertions.mustBeInAcceptingState(kt);
 		Assertions.mustBeInAcceptingState(ksh);
 		
+		@SuppressWarnings("deprecation")
 		PublicKeySign pks = PublicKeySignFactory.getPrimitive(ksh);
 		
 		String data = "this is just a test using digital signatures using Google Tink";
@@ -111,6 +114,7 @@ public class TestDigitalSignature extends TestTinkPrimitives {
 		Assertions.hasEnsuredPredicate(publicKsh);
 
 		
+		@SuppressWarnings("deprecation")
 		PublicKeyVerify pkv = PublicKeyVerifyFactory.getPrimitive(publicKsh);
 		Assertions.hasEnsuredPredicate(pkv);
 		

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,7 +6,7 @@ pipeline {
     }
     
     environment {
-        MAVEN_OPTS = ' -Xss100M -Xmx12g'
+        MAVEN_OPTS = ' -Xss128M -Xmx16g'
     }
 
     stages {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,10 +4,6 @@ pipeline {
     tools { 
         jdk 'Oracle JDK 9' 
     }
-    
-    environment {
-        MAVEN_OPTS = ' -Xss128M -Xmx16g'
-    }
 
     stages {
 


### PR DESCRIPTION
This PR fixes various test cases that were failing due to the upgrade of JCA in 1.5.0. The test cases were initially causing failures in the develop branch of CryptoAnalysis. The branch is still failing due to issue  #240 