### PR TITLE
Fix abstractError bug when error location is at ReturnVoidStmt

### DIFF
--- a/CryptoAnalysis/src/main/java/crypto/analysis/errors/AbstractError.java
+++ b/CryptoAnalysis/src/main/java/crypto/analysis/errors/AbstractError.java
@@ -4,6 +4,7 @@ import boomerang.jimple.Statement;
 import crypto.rules.CrySLRule;
 import soot.jimple.internal.JAssignStmt;
 import soot.jimple.internal.JReturnStmt;
+import soot.jimple.internal.JReturnVoidStmt;
 
 public abstract class AbstractError implements IError{
 	private Statement errorLocation;
@@ -21,7 +22,8 @@ public abstract class AbstractError implements IError{
 		if(errorLocation.getUnit().get().containsInvokeExpr()) {
 			this.invokeMethod = errorLocation.getUnit().get().getInvokeExpr().getMethod().toString();
 		}
-		else if(errorLocation.getUnit().get() instanceof JReturnStmt) {
+		else if(errorLocation.getUnit().get() instanceof JReturnStmt
+			|| errorLocation.getUnit().get() instanceof JReturnVoidStmt) {
 			this.invokeMethod = errorLocation.getUnit().get().toString();
 		}
 		else {


### PR DESCRIPTION
This issue is mentioned previously:
https://github.com/CROSSINGTUD/CryptoAnalysis/pull/219#commitcomment-39481464

It is caused by the fact that JReturnVoidStmt is not an instance of
JAssignStmt, so the default condition cast attempt will fail in some cases.

Signed-off-by: Kristen Newbury <knewbury@ualberta.ca>