### PR TITLE
Downgrade Tink dependency

### DIFF
--- a/CryptoAnalysis/pom.xml
+++ b/CryptoAnalysis/pom.xml
@@ -281,7 +281,7 @@
 		<dependency>
 			<groupId>com.google.crypto.tink</groupId>
 			<artifactId>tink</artifactId>
-			<version>1.5.0</version>
+			<version>1.3.0</version>
 			<scope>test</scope>
 		</dependency>
 		<!-- https://mvnrepository.com/artifact/com.google.code.gson/gson -->


### PR DESCRIPTION
Downgrade Tink dependency to get rid of errors in the tests.