### PR TITLE
Fix failing build of develop branch in Jenkins CI

### DIFF
--- a/CryptoAnalysis/pom.xml
+++ b/CryptoAnalysis/pom.xml
@@ -324,6 +324,11 @@
        		<artifactId>jackson-databind</artifactId>
         	<version>2.11.2</version>
 		</dependency>
+		<dependency>
+    		<groupId>commons-io</groupId>
+    		<artifactId>commons-io</artifactId>
+    		<version>2.8.0</version>
+		</dependency>
 	</dependencies>
 
 	<distributionManagement>

--- a/CryptoAnalysis/pom.xml
+++ b/CryptoAnalysis/pom.xml
@@ -258,7 +258,7 @@
 		<dependency>
 			<groupId>org.apache.maven.plugins</groupId>
 			<artifactId>maven-invoker-plugin</artifactId>
-			<version>3.2.2</version>
+			<version>3.2.1</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/CryptoAnalysis/src/main/java/crypto/reporting/CSVReporter.java
+++ b/CryptoAnalysis/src/main/java/crypto/reporting/CSVReporter.java
@@ -184,7 +184,11 @@ public class CSVReporter extends ErrorMarkerListener {
 			}
 			writer.write(Joiner.on(CSV_SEPARATOR).join(line) + "\n");
 			writer.write("\n"+SARIFConfig.ANALYSISTOOL_NAME_VALUE+"\n");
-			writer.write(getClass().getPackage().getImplementationVersion());
+			String version = getClass().getPackage().getImplementationVersion();
+			if(version == null) {
+				version = "Version is not known";
+			}
+			writer.write(version);
 			writer.close();
 			LOGGER.info("CSV Report generated to file : "+ reportDir.getAbsolutePath() + File.separator+ REPORT_NAME);
 		} catch (IOException e) {

--- a/CryptoAnalysis/src/test/java/tests/headless/ReportFormatTest.java
+++ b/CryptoAnalysis/src/test/java/tests/headless/ReportFormatTest.java
@@ -11,6 +11,7 @@ public class ReportFormatTest extends AbstractHeadlessTest{
 	private static final String txtReportPath = "cognicrypt-output/CryptoAnalysis-Report.txt";
 	private static final String csvReportPath = "cognicrypt-output/CryptoAnalysis-Report.csv";
 	private static final String sarifReportPath = "cognicrypt-output/CryptoAnalysis-Report.json";
+	
 	@Test
 	public void TXTReportCreationTest() {
 		File report = new File(txtReportPath);

--- a/CryptoAnalysis/src/test/java/tests/headless/ReportFormatTest.java
+++ b/CryptoAnalysis/src/test/java/tests/headless/ReportFormatTest.java
@@ -1,6 +1,10 @@
 package tests.headless;
 
 import java.io.File;
+import java.io.IOException;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
 import crypto.HeadlessCryptoScanner;
@@ -8,9 +12,10 @@ import crypto.analysis.CryptoScannerSettings.ReportFormat;
 
 public class ReportFormatTest extends AbstractHeadlessTest{
 
-	private static final String txtReportPath = "cognicrypt-output/CryptoAnalysis-Report.txt";
-	private static final String csvReportPath = "cognicrypt-output/CryptoAnalysis-Report.csv";
-	private static final String sarifReportPath = "cognicrypt-output/CryptoAnalysis-Report.json";
+	private static final String rootPath = "cognicrypt-output/";
+	private static final String txtReportPath = rootPath+"CryptoAnalysis-Report.txt";
+	private static final String csvReportPath = rootPath+"CryptoAnalysis-Report.csv";
+	private static final String sarifReportPath = rootPath+"CryptoAnalysis-Report.json";
 	
 	@Test
 	public void TXTReportCreationTest() {
@@ -55,6 +60,15 @@ public class ReportFormatTest extends AbstractHeadlessTest{
 		HeadlessCryptoScanner scanner = createScanner(mavenProject);
 		scanner.exec();
 		Assert.assertTrue(report.exists());
+	}
+	
+	@After
+	public void tearDown() {
+		try {
+			FileUtils.deleteDirectory(new File(rootPath));
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
 	}
 	
 }


### PR DESCRIPTION
This PR fixes the failing build of CryptoAnalysis in Jenkins CI. It introduces two fixes. Firstly, it downgrades the dependency of `maven-invoker-plugin` since the newer one introduces many API changes and as a result, many test cases are failing. Secondly, it fixes the NullPointerException error that was happening in one of the headless test cases.