### PR TITLE
Fix redundant loading of rules in HeadlessCryptoScanner

### DIFF
--- a/CryptoAnalysis/src/main/java/crypto/HeadlessCryptoScanner.java
+++ b/CryptoAnalysis/src/main/java/crypto/HeadlessCryptoScanner.java
@@ -334,6 +334,12 @@ public abstract class HeadlessCryptoScanner {
 	}
 	
 	protected abstract List<CrySLRule> getRules();
+	
+	// used to set the rules when they are loaded from headless
+	// tests and not from CLI
+	public static void setRules(List<CrySLRule> rules) {
+		HeadlessCryptoScanner.rules = rules;
+	}
 
 	protected abstract String applicationClassPath();
 

--- a/CryptoAnalysis/src/main/java/crypto/HeadlessCryptoScanner.java
+++ b/CryptoAnalysis/src/main/java/crypto/HeadlessCryptoScanner.java
@@ -137,7 +137,7 @@ public abstract class HeadlessCryptoScanner {
 	}
 	
 	private void checkIfUsesObject() {
-		final SeedFactory seedFactory = new SeedFactory(getRules());
+		final SeedFactory seedFactory = new SeedFactory(HeadlessCryptoScanner.rules);
 		PackManager.v().getPack("jap").add(new Transform("jap.myTransform", new BodyTransformer() {
 			protected void internalTransform(Body body, String phase, Map options) {
 				if (!body.getMethod().getDeclaringClass().isApplicationClass()) {
@@ -177,7 +177,7 @@ public abstract class HeadlessCryptoScanner {
 				BoomerangPretransformer.v().reset();
 				BoomerangPretransformer.v().apply();
 				ObservableDynamicICFG observableDynamicICFG = new ObservableDynamicICFG(false);
-				List<CrySLRule> rules = HeadlessCryptoScanner.this.getRules();
+				List<CrySLRule> rules = HeadlessCryptoScanner.rules;
 				ErrorMarkerListener fileReporter;
 				if(reportFormat()!= null) {
 					switch (reportFormat()) {

--- a/CryptoAnalysis/src/test/java/tests/headless/AbstractHeadlessTest.java
+++ b/CryptoAnalysis/src/test/java/tests/headless/AbstractHeadlessTest.java
@@ -9,6 +9,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.HashBasedTable;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Table;
 import com.google.common.collect.Table.Cell;
@@ -90,7 +91,10 @@ public abstract class AbstractHeadlessTest {
 			@Override
 			protected List<CrySLRule> getRules() {
 				try {
-					return CrySLRulesetSelector.makeFromRuleset(IDEALCrossingTestingFramework.RULES_BASE_DIR, ruleFormat, ruleset);
+					List<CrySLRule> rules = Lists.newArrayList();
+					rules = CrySLRulesetSelector.makeFromRuleset(IDEALCrossingTestingFramework.RULES_BASE_DIR, ruleFormat, ruleset);
+					HeadlessCryptoScanner.setRules(rules);
+					return rules;
 				} catch (CryptoAnalysisException e) {
 					LOGGER.error("Error happened when getting the CrySL rules from the specified directory: "+IDEALCrossingTestingFramework.RULES_BASE_DIR, e);
 				}


### PR DESCRIPTION
This PR fixes #353 after the issue was noticed by @Projucti. The redundant calls of the `getRules()` method are replaced with the usage of the `rules` field.

It is tested by running the CryptoAnalysis JAR in my machine and test its functionality manually. Furthermore, automatic tests complete successfully.
