### PR TITLE
Fix check on negated alternatives

### DIFF
--- a/CryptoAnalysis/src/main/java/crypto/analysis/AnalysisSeedWithSpecification.java
+++ b/CryptoAnalysis/src/main/java/crypto/analysis/AnalysisSeedWithSpecification.java
@@ -408,7 +408,7 @@ public class AnalysisSeedWithSpecification extends IAnalysisSeed {
 				
 				if (negatives.size() == alternatives.size()) {
 					for (EnsuredCrySLPredicate ensPred : ensuredPredicates) {
-						if (alternatives.parallelStream().anyMatch(e -> e.getPredName().equals(ensPred.getPredicate().getPredName()))) {
+						if (alternatives.parallelStream().allMatch(e -> e.getPredName().equals(ensPred.getPredicate().getPredName()))) {
 							return false;
 						}
 					}

--- a/CryptoAnalysis/src/main/java/crypto/analysis/CrySLRulesetSelector.java
+++ b/CryptoAnalysis/src/main/java/crypto/analysis/CrySLRulesetSelector.java
@@ -34,7 +34,7 @@ public class CrySLRulesetSelector {
 	 * current RuleSets
 	 */
 	public static enum Ruleset {
-		JavaCryptographicArchitecture, BouncyCastle, Tink
+		JavaCryptographicArchitecture, BouncyCastle, Tink, SpecialRulesForTests
 	}
 
 	/**

--- a/CryptoAnalysis/src/test/java/test/UsagePatternTestingFramework.java
+++ b/CryptoAnalysis/src/test/java/test/UsagePatternTestingFramework.java
@@ -62,6 +62,7 @@ import sync.pds.solver.nodes.Node;
 import test.assertions.Assertions;
 import test.assertions.CallToForbiddenMethodAssertion;
 import test.assertions.ConstraintErrorCountAssertion;
+import test.assertions.ErrorCountAssertion;
 import test.assertions.ExtractedValueAssertion;
 import test.assertions.HasEnsuredPredicateAssertion;
 import test.assertions.InAcceptingStateAssertion;
@@ -213,6 +214,12 @@ public abstract class UsagePatternTestingFramework extends AbstractTestingFramew
 										
 									}
 								});
+								
+								for(Assertion a : expectedResults){
+									if(a instanceof ErrorCountAssertion){
+										((ErrorCountAssertion) a).increase();
+									}
+								}
 							}
 
 							@Override
@@ -423,6 +430,13 @@ public abstract class UsagePatternTestingFramework extends AbstractTestingFramew
 				Val val = new Val(queryVar,m);
 				queries.add(new InAcceptingStateAssertion(stmt, val));
 			}
+			if(invocationName.startsWith("errorCount")){
+				Value param = invokeExpr.getArg(0);
+				if (!(param instanceof IntConstant))
+					continue;
+				IntConstant queryVal = (IntConstant) param;
+				queries.add(new ErrorCountAssertion(queryVal.value));
+			}
 			
 //			if (invocationName.startsWith("violatedConstraint")) {
 //				queries.add(new ConstraintViolationAssertion(stmt));
@@ -458,6 +472,7 @@ public abstract class UsagePatternTestingFramework extends AbstractTestingFramew
 			if(invocationName.startsWith("predicateContradiction")){
 				queries.add(new PredicateContradiction());
 			}
+			
 			if(invocationName.startsWith("missingTypestateChange")){
 				for(Unit pred : getPredecessorsNotBenchmark(stmt))
 					queries.add(new MissingTypestateChange((Stmt) pred));

--- a/CryptoAnalysis/src/test/java/test/assertions/Assertions.java
+++ b/CryptoAnalysis/src/test/java/test/assertions/Assertions.java
@@ -46,6 +46,12 @@ public class Assertions {
 
 	public static void predicateContradiction() {
 	}
+	
+	public static void predicateContradiction(boolean shouldBeCondradicted) {
+	}
+	
+	public static void errorCount(int expectedCount) {
+	}
 
 	public static void predicateErrors(int i) {
 		

--- a/CryptoAnalysis/src/test/java/test/assertions/ErrorCountAssertion.java
+++ b/CryptoAnalysis/src/test/java/test/assertions/ErrorCountAssertion.java
@@ -1,0 +1,32 @@
+package test.assertions;
+
+import test.Assertion;
+
+public class ErrorCountAssertion implements Assertion {
+
+	private int expectedCount;
+	private int actualCount = 0;
+	
+	public ErrorCountAssertion(int expectedCount) {
+		this.expectedCount = expectedCount;
+	}
+
+	@Override
+	public boolean isSatisfied() {
+		return expectedCount == actualCount;
+	}
+
+	@Override
+	public boolean isImprecise() {
+		return false;
+	}
+
+	@Override
+	public String toString() {
+		return "Expected " + expectedCount + " Errors, but found " + actualCount + ".";
+	}
+
+	public void increase() {
+		actualCount++;
+	}
+}

--- a/CryptoAnalysis/src/test/java/test/assertions/PredicateContradiction.java
+++ b/CryptoAnalysis/src/test/java/test/assertions/PredicateContradiction.java
@@ -5,10 +5,20 @@ import test.Assertion;
 public class PredicateContradiction implements Assertion{
 
 	private boolean triggered;
+	boolean shouldBeContradiced = true;
+	
+	public PredicateContradiction() {
+		super();
+	}
+	
+	public PredicateContradiction(boolean shouldBeContradiced) {
+		super();
+		this.shouldBeContradiced = shouldBeContradiced;
+	}
 
 	@Override
 	public boolean isSatisfied() {
-		return triggered;
+		return shouldBeContradiced == triggered;
 	}
 
 	@Override

--- a/CryptoAnalysis/src/test/java/tests/pattern/specialrules/SpecialRulesTest.java
+++ b/CryptoAnalysis/src/test/java/tests/pattern/specialrules/SpecialRulesTest.java
@@ -1,0 +1,31 @@
+package tests.pattern.specialrules;
+
+import java.security.SecureRandom;
+import org.junit.Test;
+
+
+import crypto.analysis.CrySLRulesetSelector.Ruleset;
+import test.UsagePatternTestingFramework;
+import test.assertions.Assertions;
+
+public class SpecialRulesTest extends UsagePatternTestingFramework {
+	
+	@Override
+	protected Ruleset getRuleSet() {
+		return Ruleset.SpecialRulesForTests;
+	}
+	
+	@Test
+	public void alternativeNegatedPreds() {
+		SecureRandom sr = new SecureRandom();
+		byte[] genSeed = new byte[32];
+		sr.nextBytes(genSeed); // this ensured genSeed as test
+		Assertions.hasEnsuredPredicate(genSeed);
+		SecureRandom sr2 = new SecureRandom();
+		sr2.nextBytes(genSeed); 
+		// genSeed should be either !test or !test2
+		// since test2 was nowhere ensured, the result should throw no errors
+		Assertions.errorCount(0); // this fails
+	}
+	
+}


### PR DESCRIPTION
# How does the check work?
CrySL required preds will be stored as `CrySLConstraint`s. The `ConstraintSolvers` will convert required `CrySLConstraint`s to `AlternativeReqPredicates`, see here https://github.com/CROSSINGTUD/CryptoAnalysis/blob/35d09163f97b6919a4359fcaa0e846af95c1fed1/CryptoAnalysis/src/main/java/crypto/constraints/ConstraintSolver.java#L111
All required preds, also the `AlternativeReqPredicate`s, will be used to check wether a `AnalysisSeedWithSpecification` satisfies its required predicates or not in the `checkPredicates()` method. https://github.com/CROSSINGTUD/CryptoAnalysis/blob/35d09163f97b6919a4359fcaa0e846af95c1fed1/CryptoAnalysis/src/main/java/crypto/analysis/AnalysisSeedWithSpecification.java#L377

# What is the issue?
Checking on an `AlternativeReqPredicate` with all alternative predicates negated - keep in mind that they are connected with a logical or - is done by returning false (false = predicates does not satisfy constraints) if only *one* negated alternative predicate is ensured by the seed. 
That is wrong, because it should actually satisfy its constraints, if at least one negated alternative predicate is not ensured, since they are connected with a logical or.

# This needs to be testet first
Current tests does not cover this code, so someone should write tests before merging.
