### PR TITLE
Refactor finite state machine builder

### DIFF
--- a/CryptoAnalysis/src/main/java/crypto/cryslhandler/CrySLModelReader.java
+++ b/CryptoAnalysis/src/main/java/crypto/cryslhandler/CrySLModelReader.java
@@ -85,6 +85,7 @@ import de.darmstadt.tu.crossing.crySL.PreDefinedPredicates;
 import de.darmstadt.tu.crossing.crySL.Pred;
 import de.darmstadt.tu.crossing.crySL.PredLit;
 import de.darmstadt.tu.crossing.crySL.ReqPred;
+import de.darmstadt.tu.crossing.crySL.RequiredBlock;
 import de.darmstadt.tu.crossing.crySL.SimpleOrder;
 import de.darmstadt.tu.crossing.crySL.SuPar;
 import de.darmstadt.tu.crossing.crySL.SuParList;
@@ -188,6 +189,7 @@ public class CrySLModelReader {
 		final EObject eObject = resource.getContents().get(0);
 		final Domainmodel dm = (Domainmodel) eObject;
 		String curClass = dm.getJavaType().getQualifiedName();
+		final RequiredBlock events = dm.getReq_events(); 
 		final EnsuresBlock ensure = dm.getEnsure();
 		final Map<ParEqualsPredicate, SuperType> pre_preds = Maps.newHashMap();
 		final DestroysBlock destroys = dm.getDestroy();
@@ -203,7 +205,7 @@ public class CrySLModelReader {
 			pre_preds.putAll(getPredicates(ensure.getPred()));
 		}
 
-		this.smg = buildStateMachineGraph(order);
+		this.smg = (new NewStateMachineGraphBuilder(order)).buildSMG();
 		final ForbiddenBlock forbEvent = dm.getForbEvent();
 		this.forbiddenMethods = (forbEvent != null) ? getForbiddenMethods(forbEvent.getForb_methods()) : Lists.newArrayList();
 

--- a/CryptoAnalysis/src/main/java/crypto/cryslhandler/NewStateMachineGraphBuilder.java
+++ b/CryptoAnalysis/src/main/java/crypto/cryslhandler/NewStateMachineGraphBuilder.java
@@ -84,10 +84,8 @@ public class NewStateMachineGraphBuilder {
 		List<StateNode> endNodes = Lists.newArrayList();
 		if(order.getOrderop() == null) {
 			// This must by of type Primary
-			// (orderEv+=[Event] elementop=('+' | '?' | '*')?) | ('(' Order ')' elementop=('+' | '?' | '*')?);
 			if(!order.getOrderEv().isEmpty()) {
 				// That is actually the end of recursion or the deepest level.
-				// 
 				StateNode endNode = this.getNewNode();
 				this.result.addNode(endNode);
 				endNodes.add(endNode);
@@ -97,12 +95,10 @@ public class NewStateMachineGraphBuilder {
 			}
 		} else if(order.getOrderop().equals(",")) {
 			// This must by of type Order
-			// SimpleOrder ({Order.left=current} orderop=',' right=SimpleOrder)* | '*';
 			List<StateNode> leftEndNodes =  parseOrderAndGetEndStates(order.getLeft(), startNodes, false);
 			endNodes = parseOrderAndGetEndStates(order.getRight(), leftEndNodes, false);
 		} else if(order.getOrderop().equals("|")) {
 			// This must by of type SimpleOrder
-			// Primary ({SimpleOrder.left=current} orderop='|' right=Primary)*;
 			List<StateNode> leftEndNodes =  parseOrderAndGetEndStates(order.getLeft(), startNodes, false);
 			endNodes = parseOrderAndGetEndStates(order.getRight(), startNodes, false);
 			endNodes.addAll(leftEndNodes);

--- a/CryptoAnalysis/src/main/java/crypto/cryslhandler/NewStateMachineGraphBuilder.java
+++ b/CryptoAnalysis/src/main/java/crypto/cryslhandler/NewStateMachineGraphBuilder.java
@@ -1,4 +1,5 @@
 package crypto.cryslhandler;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
@@ -48,9 +49,8 @@ public class NewStateMachineGraphBuilder {
 			// Primary ({SimpleOrder.left=current} orderop='|' right=Primary)*;
 			List<StateNode> leftEndNodes =  parseOrderAndGetEndStates(order.getLeft(), startNodes, false);
 			endNodes = parseOrderAndGetEndStates(order.getRight(), startNodes, false);
+			StateNode state = leftEndNodes.remove(0);
 			endNodes.addAll(leftEndNodes);
-			StateNode state = this.getNewNode();
-			this.result.addNode(state);
 			endNodes = Lists.newArrayList(this.result.aggregateNodesToOneNode(endNodes, state));
 		}
 		String elementop = order.getElementop();
@@ -66,8 +66,7 @@ public class NewStateMachineGraphBuilder {
 			else if(elementop.equals("*")){
 				// start --> start
 				// start = end node
-				endNodes.addAll(startNodes);
-				endNodes = Lists.newArrayList(this.result.aggregateNodesToOneNode(endNodes, this.getNewNode()));
+				endNodes = Lists.newArrayList(this.result.aggregateNodestoOtherNodes(endNodes, startNodes));
 			}
 			else if(elementop.equals("?")) {
 				// start --> end node
@@ -94,9 +93,16 @@ public class NewStateMachineGraphBuilder {
 	}
 
 	public StateMachineGraph buildSMG() {
+		StateNode initialNode = null;
+		for(StateNode s: this.result.getNodes()) {
+			initialNode = s;
+		}
 		if (this.head != null) {
 			List<StateNode> acceptingNodes = parseOrderAndGetEndStates(this.head, this.result.getNodes(), false);
 			acceptingNodes.parallelStream().forEach(node -> node.setAccepting(true));
+		}
+		if(this.result.getAllTransitions().isEmpty()) {
+			this.result.addEdge(new TransitionEdge(new ArrayList<CrySLMethod>(), initialNode, initialNode));
 		}
 		return this.result;
 	}

--- a/CryptoAnalysis/src/main/java/crypto/cryslhandler/NewStateMachineGraphBuilder.java
+++ b/CryptoAnalysis/src/main/java/crypto/cryslhandler/NewStateMachineGraphBuilder.java
@@ -1,0 +1,104 @@
+package crypto.cryslhandler;
+import java.util.Collection;
+import java.util.List;
+
+import com.google.common.collect.Lists;
+
+import crypto.rules.CrySLMethod;
+import crypto.rules.StateMachineGraph;
+import crypto.rules.StateNode;
+import crypto.rules.TransitionEdge;
+import de.darmstadt.tu.crossing.crySL.Event;
+import de.darmstadt.tu.crossing.crySL.Expression;
+
+public class NewStateMachineGraphBuilder {
+	
+	private final Expression head;
+	private final StateMachineGraph result = new StateMachineGraph();
+	private int nodeNameCounter = 0;
+
+	public NewStateMachineGraphBuilder(final Expression order) {
+		this.head = order;
+		this.result.addNode(new StateNode("-1", true, true));
+	}
+	
+	private List<StateNode> parseOrderAndGetEndStates(Expression order, Collection<StateNode> startNodes, boolean ignoreElementOp) {
+		List<StateNode> endNodes = Lists.newArrayList();
+		if(order.getOrderop() == null) {
+			// Primary
+			// (orderEv+=[Event] elementop=('+' | '?' | '*')?) | ('(' Order ')' elementop=('+' | '?' | '*')?);
+			if(!order.getOrderEv().isEmpty()) {
+				StateNode endNode = this.getNewNode();
+				this.result.addNode(endNode);
+				endNodes.add(endNode);
+				parseEvent(order.getOrderEv().get(0), startNodes, endNode);
+			}
+			else {
+				//parser error
+			}
+		}
+		else if(order.getOrderop().equals(",")) {
+			// Order
+			// SimpleOrder ({Order.left=current} orderop=',' right=SimpleOrder)* | '*';
+			List<StateNode> leftEndNodes =  parseOrderAndGetEndStates(order.getLeft(), startNodes, false);
+			endNodes = parseOrderAndGetEndStates(order.getRight(), leftEndNodes, false);
+		}
+		else if(order.getOrderop().equals("|")) {
+			// SimpleOrder
+			// Primary ({SimpleOrder.left=current} orderop='|' right=Primary)*;
+			List<StateNode> leftEndNodes =  parseOrderAndGetEndStates(order.getLeft(), startNodes, false);
+			endNodes = parseOrderAndGetEndStates(order.getRight(), startNodes, false);
+			endNodes.addAll(leftEndNodes);
+			StateNode state = this.getNewNode();
+			this.result.addNode(state);
+			endNodes = Lists.newArrayList(this.result.aggregateNodesToOneNode(endNodes, state));
+		}
+		String elementop = order.getElementop();
+		if(!(elementop == null || ignoreElementOp)) {
+			if(elementop.equals("+")) {
+				// start --> end node
+				// end node --> end node
+				for(StateNode endNode: endNodes) {
+					List<StateNode> endNotesToAggr = parseOrderAndGetEndStates(order, Lists.newArrayList(endNode), true);
+					this.result.aggregateNodesToOneNode(endNotesToAggr, endNode);
+				}
+			}
+			else if(elementop.equals("*")){
+				// start --> start
+				// start = end node
+				endNodes.addAll(startNodes);
+				endNodes = Lists.newArrayList(this.result.aggregateNodesToOneNode(endNodes, this.getNewNode()));
+			}
+			else if(elementop.equals("?")) {
+				// start --> end node
+				// start & end node = end nodes
+				endNodes.addAll(startNodes);
+			}
+		}
+		return endNodes;
+	}
+	
+	private void parseEvent(Event event, Collection<StateNode> startNodes, StateNode endNode) {
+		for(StateNode startState: startNodes) {
+			parseEvent(event, startState, endNode);
+		}
+	}
+	
+	private void parseEvent(Event event, StateNode startNode, StateNode endNode) {
+		final List<CrySLMethod> label = CryslReaderUtils.resolveAggregateToMethodeNames(event);
+		this.result.addEdge(new TransitionEdge(label, startNode, endNode));
+	}
+	
+	private StateNode getNewNode() {
+		return new StateNode(String.valueOf(this.nodeNameCounter++), false, false);
+	}
+
+	public StateMachineGraph buildSMG() {
+		if (this.head != null) {
+			List<StateNode> acceptingNodes = parseOrderAndGetEndStates(this.head, this.result.getNodes(), false);
+			acceptingNodes.parallelStream().forEach(node -> node.setAccepting(true));
+		}
+		return this.result;
+	}
+	
+}

--- a/CryptoAnalysis/src/main/java/crypto/cryslhandler/NewStateMachineGraphBuilder.java
+++ b/CryptoAnalysis/src/main/java/crypto/cryslhandler/NewStateMachineGraphBuilder.java
@@ -49,9 +49,7 @@ public class NewStateMachineGraphBuilder {
 			// Primary ({SimpleOrder.left=current} orderop='|' right=Primary)*;
 			List<StateNode> leftEndNodes =  parseOrderAndGetEndStates(order.getLeft(), startNodes, false);
 			endNodes = parseOrderAndGetEndStates(order.getRight(), startNodes, false);
-			StateNode state = leftEndNodes.remove(0);
 			endNodes.addAll(leftEndNodes);
-			endNodes = Lists.newArrayList(this.result.aggregateNodesToOneNode(endNodes, state));
 		}
 		String elementop = order.getElementop();
 		if(!(elementop == null || ignoreElementOp)) {

--- a/CryptoAnalysis/src/main/java/crypto/cryslhandler/NewStateMachineGraphBuilder.java
+++ b/CryptoAnalysis/src/main/java/crypto/cryslhandler/NewStateMachineGraphBuilder.java
@@ -12,63 +12,111 @@ import crypto.rules.TransitionEdge;
 import de.darmstadt.tu.crossing.crySL.Event;
 import de.darmstadt.tu.crossing.crySL.Expression;
 
+/**
+ * This class will build a {@FiniteStateMachine} for a given ORDER expression from crysl rules.
+ * @author marvinvogel
+ *
+ */
 public class NewStateMachineGraphBuilder {
 	
-	private final Expression head;
+	private final Expression order;
 	private final StateMachineGraph result = new StateMachineGraph();
 	private int nodeNameCounter = 0;
 
 	public NewStateMachineGraphBuilder(final Expression order) {
-		this.head = order;
+		this.order = order;
 		this.result.addNode(new StateNode("-1", true, true));
 	}
 	
+	/**
+	 * This method will build the state machine. It is called recursively.
+	 * For a collection of start nodes, which must already be added to the @attr result (the StateMachineGraph), 
+	 * it will append nodes and edges to result according to the given order and return all accepting end nodes.
+	 * 
+	 * @param order the order expression from crysl.
+	 * @param startNodes nodes from which the order can start.
+	 * @param ignoreElementOp if true, it will ignore elementop (elementop=('+' | '?' | '*')). Default is false.
+	 * @return all accepting nodes, according to the order
+	 */
 	private List<StateNode> parseOrderAndGetEndStates(Expression order, Collection<StateNode> startNodes, boolean ignoreElementOp) {
+		/* Having a look at the Crysl Xtext definition for the Order section, we have
+		 * -----------
+		 *
+		 * Order returns Expression:
+		 * 	SimpleOrder ({Order.left=current} orderop=',' right=SimpleOrder)* | '*';
+		 * 
+		 * SimpleOrder returns Expression:
+		 * 	Primary ({SimpleOrder.left=current} orderop='|' right=Primary)*;
+		 * 
+		 * Primary returns Expression:
+		 * 	(orderEv+=[Event] elementop=('+' | '?' | '*')?) | ('(' Order ')' elementop=('+' | '?' | '*')?);
+		 * 
+		 * -----------
+		 * Based on this definition, the method will parse the Order section.
+		 * In detail, we seperate Order, SimpleOrder and orderEv from elementop.
+		 * To simplify this documentation, we create a synonym "ROOTS" for Order, SimpleOrder and orderEv.
+		 * As you see in the definition the elementop can be defined for any ROOT.
+		 * 
+		 * Given start nodes, we fist append ROOT's nodes and edges according to the order and will retrieve it's end nodes.
+		 * Therefore, we have three cases:
+		 * (Event): Event should be the next transition in graph. 
+		 * 			We add edges from each start to a new node with Event as label.
+		 * 			The new node is our end node.
+		 * (,):		Left side should be called before right side.
+		 * 			We recursively call this method with order.leftSide and retrieve end nodes.
+		 * 			We recursively call this method with order.rightSide use the end nodes from order.leftSide as start nodes.
+		 * 			We retrieve our final end nodes from the call with order.rightSide.
+		 * (|):		Left side or right side should be called.
+		 * 			We recursively call this method with order.leftSide and order.rightSide, with same start nodes.
+		 * 			We retrieve our final end nodes by joining both return collections.
+		 * 
+		 * Having start and end nodes, we can then modify the graph such that it applies the elementop.
+		 * Therefore, we have three cases:
+		 * ()*:		End nodes will be aggregated to the start nodes. 
+		 * 			In detail, for each transition to end nodes, a transition to each start node is created.
+		 * 			The end notes will be removed from the graph and new end nodes are the start nodes.
+		 * ()?: 	All start nodes are also end nodes.
+		 * ()+: 	This creates a loop on the end nodes. In detail, we will recursively call this method with same order,
+		 * 			but with end nodes as start nodes.
+		 * 			We set the ignoreElementOp flag, to not end in infinity loop.
+		 * 			Then we apply same as on ()*.
+		 */
 		List<StateNode> endNodes = Lists.newArrayList();
 		if(order.getOrderop() == null) {
-			// Primary
+			// This must by of type Primary
 			// (orderEv+=[Event] elementop=('+' | '?' | '*')?) | ('(' Order ')' elementop=('+' | '?' | '*')?);
 			if(!order.getOrderEv().isEmpty()) {
+				// That is actually the end of recursion or the deepest level.
+				// 
 				StateNode endNode = this.getNewNode();
 				this.result.addNode(endNode);
 				endNodes.add(endNode);
 				parseEvent(order.getOrderEv().get(0), startNodes, endNode);
+			} else {
+				//parser error: expected to have entries in orderEv
 			}
-			else {
-				//parser error
-			}
-		}
-		else if(order.getOrderop().equals(",")) {
-			// Order
+		} else if(order.getOrderop().equals(",")) {
+			// This must by of type Order
 			// SimpleOrder ({Order.left=current} orderop=',' right=SimpleOrder)* | '*';
 			List<StateNode> leftEndNodes =  parseOrderAndGetEndStates(order.getLeft(), startNodes, false);
 			endNodes = parseOrderAndGetEndStates(order.getRight(), leftEndNodes, false);
-		}
-		else if(order.getOrderop().equals("|")) {
-			// SimpleOrder
+		} else if(order.getOrderop().equals("|")) {
+			// This must by of type SimpleOrder
 			// Primary ({SimpleOrder.left=current} orderop='|' right=Primary)*;
 			List<StateNode> leftEndNodes =  parseOrderAndGetEndStates(order.getLeft(), startNodes, false);
 			endNodes = parseOrderAndGetEndStates(order.getRight(), startNodes, false);
 			endNodes.addAll(leftEndNodes);
 		}
+		
+		// modify graph such that it applies elementop.
 		String elementop = order.getElementop();
 		if(!(elementop == null || ignoreElementOp)) {
 			if(elementop.equals("+")) {
-				// start --> end node
-				// end node --> end node
-				for(StateNode endNode: endNodes) {
-					List<StateNode> endNotesToAggr = parseOrderAndGetEndStates(order, Lists.newArrayList(endNode), true);
-					this.result.aggregateNodesToOneNode(endNotesToAggr, endNode);
-				}
-			}
-			else if(elementop.equals("*")){
-				// start --> start
-				// start = end node
+				List<StateNode> endNotesToAggr = parseOrderAndGetEndStates(order, endNodes, true);
+				this.result.aggregateNodestoOtherNodes(endNotesToAggr, endNodes);
+			} else if(elementop.equals("*")){
 				endNodes = Lists.newArrayList(this.result.aggregateNodestoOtherNodes(endNodes, startNodes));
-			}
-			else if(elementop.equals("?")) {
-				// start --> end node
-				// start & end node = end nodes
+			} else if(elementop.equals("?")) {
 				endNodes.addAll(startNodes);
 			}
 		}
@@ -95,8 +143,8 @@ public class NewStateMachineGraphBuilder {
 		for(StateNode s: this.result.getNodes()) {
 			initialNode = s;
 		}
-		if (this.head != null) {
-			List<StateNode> acceptingNodes = parseOrderAndGetEndStates(this.head, this.result.getNodes(), false);
+		if (this.order != null) {
+			List<StateNode> acceptingNodes = parseOrderAndGetEndStates(this.order, this.result.getNodes(), false);
 			acceptingNodes.parallelStream().forEach(node -> node.setAccepting(true));
 		}
 		if(this.result.getAllTransitions().isEmpty()) {

--- a/CryptoAnalysis/src/main/java/crypto/rules/StateMachineGraph.java
+++ b/CryptoAnalysis/src/main/java/crypto/rules/StateMachineGraph.java
@@ -6,6 +6,8 @@ import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
+
 import crypto.interfaces.FiniteStateMachine;
 
 public final class StateMachineGraph implements FiniteStateMachine<StateNode>, java.io.Serializable {
@@ -39,6 +41,16 @@ public final class StateMachineGraph implements FiniteStateMachine<StateNode>, j
 			e.setHopsToAccepting(0);
 			updateHops(e);
 		});
+	}
+	
+	public StateNode aggregateNodesToOneNode(List<StateNode> nodesToAggr, StateNode newNode) {
+		List<TransitionEdge> edgesToAnyAggrNode = edges.parallelStream().filter(e -> nodesToAggr.contains(e.to())).collect(Collectors.toList());
+		// Add new edges to newNode instead of Aggr Node 
+		edgesToAnyAggrNode.forEach(edgeToAggrNode -> this.addEdge(new TransitionEdge(edgeToAggrNode.getLabel(), edgeToAggrNode.getLeft(), newNode)));
+		// remove Aggr nodes and edges
+		edges.removeAll(edgesToAnyAggrNode);
+		nodes.removeAll(nodesToAggr);
+		return newNode;
 	}
 
 	private void updateHops(StateNode node) {

--- a/CryptoAnalysis/src/main/java/crypto/rules/StateMachineGraph.java
+++ b/CryptoAnalysis/src/main/java/crypto/rules/StateMachineGraph.java
@@ -48,9 +48,32 @@ public final class StateMachineGraph implements FiniteStateMachine<StateNode>, j
 		// Add new edges to newNode instead of Aggr Node 
 		edgesToAnyAggrNode.forEach(edgeToAggrNode -> this.addEdge(new TransitionEdge(edgeToAggrNode.getLabel(), edgeToAggrNode.getLeft(), newNode)));
 		// remove Aggr nodes and edges
-		edges.removeAll(edgesToAnyAggrNode);
-		nodes.removeAll(nodesToAggr);
+		nodesToAggr.remove(newNode);
+		removeNodesWithAllEdges(nodesToAggr);
 		return newNode;
+	}
+	
+	public Collection<StateNode> aggregateNodestoOtherNodes(Collection<StateNode> nodesToAggr, Collection<StateNode> startNodes){
+		List<TransitionEdge> edgesToAnyAggrNode = edges.parallelStream().filter(e -> nodesToAggr.contains(e.to())).collect(Collectors.toList());
+		// Add new edges to newNode instead of Aggr Node 
+		startNodes.forEach(node -> edgesToAnyAggrNode.forEach(edgeToAggrNode -> this.addEdge(new TransitionEdge(edgeToAggrNode.getLabel(), edgeToAggrNode.getLeft(), node))));
+		nodesToAggr.removeAll(startNodes);
+		removeNodesWithAllEdges(nodesToAggr);
+		return startNodes;
+	}
+	
+	private void removeNodesWithAllEdges(Collection<StateNode> nodesToRemove) {
+		nodesToRemove.forEach(node -> removeNodeWithAllEdges(node));
+	}
+	
+	private void removeNodeWithAllEdges(StateNode node) {
+		removeAllEdgesWithNode(node);
+		nodes.remove(node);
+	}
+	
+	private void removeAllEdgesWithNode(StateNode node) {
+		List<TransitionEdge> filteredEdges = edges.parallelStream().filter(e -> node.equals(e.to()) || node.equals(e.from())).collect(Collectors.toList());
+		edges.removeAll(filteredEdges);
 	}
 
 	private void updateHops(StateNode node) {


### PR DESCRIPTION
This will reduce raw code from 470 line to 100.

Further, this will fix some issues. For example, having the code
````
Security.addProvider(new BouncyCastleProvider());
byte[] msg1 = ("demo msg").getBytes();
KeyPairGenerator g = KeyPairGenerator.getInstance("RSA", "BC");
g.initialize(2048);
KeyPair kp = g.generateKeyPair();

Cipher enc = Cipher.getInstance("RSA/ECB/NoPadding", "BC");
enc.init(Cipher.ENCRYPT_MODE, kp.getPublic());
Cipher dec = Cipher.getInstance("RSA/ECB/NoPadding", "BC");
dec.init(Cipher.DECRYPT_MODE, kp.getPrivate());

byte[][] ct = new byte[2][];
for (int i = 0; i < 2; i++) {
ct[i] = enc.doFinal(msg1);
byte[] deciphered = dec.doFinal(ct[i]);
}
````

the current version of CryptoAnalysis will output two typestate errors:

````
TypestateError violating CrySL rule for javax.crypto.Cipher (on Object #75285e3bccff5a304866a0372be702c99ffe81fd49a0d874558a131c283a5777)
	Unexpected call to method doFinal on object of type javax.crypto.Cipher.
	at statement: virtualinvoke r6.<javax.crypto.Cipher: byte[] doFinal(byte[])>($r10)

TypestateError violating CrySL rule for javax.crypto.Cipher (on Object #7604fd7626aea8b11e4167f40971b912a12364ebd00e3a8cc2b362096f258612)
	Unexpected call to method doFinal on object of type javax.crypto.Cipher.
	at statement: $r9 = virtualinvoke r4.<javax.crypto.Cipher: byte[] doFinal(byte[])>(r14)
````

These are actually false positives. Having a look at the order section of Cipher, the typestate is satisfied with calls to Get, Init -> FINWOU -> FINWOU
https://github.com/CROSSINGTUD/Crypto-API-Rules/blob/61f7449564330c462738926fd5bb4e214edb4f23/BouncyCastle-JCA/src/Cipher.crysl#L85

There are probably more false positives. Some headless tests does not match with old typestate error counts so I definitely will check them and report in this thread. 