### PR TITLE
Fix Nullpointer in SARIF

### DIFF
--- a/CryptoAnalysis/src/main/java/crypto/reporting/SARIFConfig.java
+++ b/CryptoAnalysis/src/main/java/crypto/reporting/SARIFConfig.java
@@ -60,5 +60,7 @@ public class SARIFConfig {
 	public static final String REQUIRED_PREDICATE_ERROR_VALUE = "An object A expects an object B to have been used correctly (CrySL blocks REQUIRES and ENSURES). For example a Cipher object requires a SecretKey object to be correctly and securely generated.";
 	public static final String INCOMPLETE_OPERATION_ERROR_KEY = "IncompleteOperationError";
 	public static final String INCOMPLETE_OPERATION_ERROR_VALUE = "The usage of an object may be incomplete: For example a Cipherobject may be initialized but never used for en- or decryption, this may render the code dead. This error heavily depends on the computed call graph (CHA by default)";
+	public static final String INSTANCE_OF_ERROR_KEY = "InstanceOfError";
+	public static final String INSTANCE_OF_ERROR_VALUE = "Reported when a value was found to not be of a certain instance.";
 	
 }

--- a/CryptoAnalysis/src/main/java/crypto/reporting/SARIFReporter.java
+++ b/CryptoAnalysis/src/main/java/crypto/reporting/SARIFReporter.java
@@ -66,6 +66,8 @@ public class SARIFReporter extends ErrorMarkerListener {
 	private void initializeMap() {
 		this.errorCountMap.put(SARIFConfig.CONSTRAINT_ERROR_KEY, 0);
 		this.errorCountMap.put(SARIFConfig.NEVER_TYPE_OF_ERROR_KEY, 0);
+		this.errorCountMap.put(SARIFConfig.HARDCODED_ERROR_KEY, 0);
+		this.errorCountMap.put(SARIFConfig.INSTANCE_OF_ERROR_KEY, 0);
 		this.errorCountMap.put(SARIFConfig.FORBIDDEN_METHOD_ERROR_KEY, 0);
 		this.errorCountMap.put(SARIFConfig.IMPRECISE_VALUE_EXTRACTION_ERROR_KEY, 0);
 		this.errorCountMap.put(SARIFConfig.TYPE_STATE_ERROR_KEY, 0);


### PR DESCRIPTION
SARIF report has thrown Nullpointer exceptions whenever CryptoAnalysis reported a HardcodedError or InstanceOfError.