### PR TITLE
Throw an exception if the ORDER section cannot be parsed correctly

### DIFF
--- a/CryptoAnalysis/src/main/java/crypto/HeadlessCryptoScanner.java
+++ b/CryptoAnalysis/src/main/java/crypto/HeadlessCryptoScanner.java
@@ -88,7 +88,8 @@ public abstract class HeadlessCryptoScanner {
 							rules.addAll(CrySLRuleReader.readFromDirectory(new File(settings.getRulesetPathDir())));
 							rulesetRootPath = settings.getRulesetPathDir().substring(0, settings.getRulesetPathDir().lastIndexOf(File.separator));
 						} catch (CryptoAnalysisException e) {
-							LOGGER.error("Error happened when getting the CrySL rules from the specified directory: "+settings.getRulesetPathDir(), e);
+							LOGGER.error("Error happened when getting the CrySL rules from the specified directory: " + settings.getRulesetPathDir(), e);
+							e.printStackTrace();
 						}
 						break;
 					case ZIP:
@@ -96,7 +97,7 @@ public abstract class HeadlessCryptoScanner {
 							rules.addAll(CrySLRuleReader.readFromZipFile(new File(settings.getRulesetPathZip())));
 							rulesetRootPath = settings.getRulesetPathZip().substring(0, settings.getRulesetPathZip().lastIndexOf(File.separator));
 						} catch (CryptoAnalysisException e) {
-							LOGGER.error("Error happened when getting the CrySL rules from the specified file: "+settings.getRulesetPathZip(), e);
+							LOGGER.error("Error happened when getting the CrySL rules from the specified file: " + settings.getRulesetPathZip(), e);
 						}
 						break;
 					default:

--- a/CryptoAnalysis/src/main/java/crypto/cryslhandler/CrySLModelReader.java
+++ b/CryptoAnalysis/src/main/java/crypto/cryslhandler/CrySLModelReader.java
@@ -139,6 +139,13 @@ public class CrySLModelReader {
 		final DestroysBlock destroys = dm.getDestroy();
 
 		Expression order = dm.getOrder();
+		
+		if (order == null) {
+			throw new CryptoAnalysisException("An error occurred while parsing the ORDER section from the ruleset for "
+					+ "class " + curClass + ". Please make sure that the expression is valid "
+					+ "(see https://github.com/CROSSINGTUD/CryptoAnalysis/issues/365 for more information).");
+		}
+		
 		if (order instanceof Order) {
 			validateOrder((Order) order);
 		}


### PR DESCRIPTION
If CryptoAnalysis is not able to parse the `ORDER` section in a CrySL file (i.e. the expression is not valid or the `ORDER` section is missing), it will not consider the rules for the corresponding classes (e.g. no constraints are checked). Since CrySL defines the ORDER section to be mandatory, this behaviour is correct. However, CryptoAnalysis didn't throw any error for a wrong `ORDER` section, which should be fixed now.

## Issues
This PR should fix #365 