### PR TITLE
Update tests to match BC 3.1.0 and JCA 3.0.2

### DIFF
--- a/CryptoAnalysis/pom.xml
+++ b/CryptoAnalysis/pom.xml
@@ -87,7 +87,7 @@
 								<artifactItem>
 									<groupId>de.darmstadt.tu.crossing</groupId>
 									<artifactId>JavaCryptographicArchitecture</artifactId>
-									<version>3.0.1</version>
+									<version>3.0.2</version>
 									<classifier>ruleset</classifier>
 									<type>zip</type>
 									<overWrite>true</overWrite>
@@ -97,7 +97,7 @@
 								<artifactItem>
 									<groupId>de.fraunhofer.iem</groupId>
 									<artifactId>BouncyCastle</artifactId>
-									<version>3.0.0</version>
+									<version>3.1.0</version>
 									<classifier>ruleset</classifier>
 									<type>zip</type>
 									<overWrite>true</overWrite>
@@ -117,7 +117,7 @@
 								<artifactItem>
 									<groupId>de.paderborn.uni</groupId>
 									<artifactId>BouncyCastle-JCA</artifactId>
-									<version>3.0.1</version>
+									<version>3.0.2</version>
 									<classifier>ruleset</classifier>
 									<type>zip</type>
 									<overWrite>true</overWrite>

--- a/CryptoAnalysis/src/main/java/crypto/cryslhandler/CrySLModelReader.java
+++ b/CryptoAnalysis/src/main/java/crypto/cryslhandler/CrySLModelReader.java
@@ -278,7 +278,11 @@ public class CrySLModelReader {
 		final List<ISLConstraint> constraints = Lists.newArrayList();
 		constraints.addAll(getConstraints(model.getConstraints()));
 		constraints.addAll(getRequiredPredicates(model.getRequires()));
-		constraints.addAll(ExceptionsReader.getExceptionConstraints(eventsBlock));
+		
+		// Since 3.0.0: All sections are optional
+		if (eventsBlock != null) {
+			constraints.addAll(ExceptionsReader.getExceptionConstraints(eventsBlock));
+		}
 
 		final EnsuresBlock ensuresBlock = model.getEnsures();
 		final NegatesBlock negatesBlock = model.getNegates();

--- a/CryptoAnalysis/src/test/java/tests/headless/BouncyCastleHeadlessTest.java
+++ b/CryptoAnalysis/src/test/java/tests/headless/BouncyCastleHeadlessTest.java
@@ -7,28 +7,38 @@ import org.junit.Test;
 
 import crypto.HeadlessCryptoScanner;
 import crypto.analysis.CrySLRulesetSelector.Ruleset;
+import crypto.analysis.errors.ForbiddenMethodError;
 import crypto.analysis.errors.HardCodedError;
-import crypto.analysis.errors.ImpreciseValueExtractionError;
 import crypto.analysis.errors.IncompleteOperationError;
+import crypto.analysis.errors.NeverTypeOfError;
 import crypto.analysis.errors.RequiredPredicateError;
 import crypto.analysis.errors.TypestateError;
 import tests.headless.FindingsType.TruePositives;
 
 public class BouncyCastleHeadlessTest extends AbstractHeadlessTest {
-	@Ignore
+	
 	@Test
 	public void testBCMacExamples() {
 		String mavenProjectPath = new File("../CryptoAnalysisTargets/BCMacExamples").getAbsolutePath();
 		MavenProject mavenProject = createAndCompile(mavenProjectPath);
 		HeadlessCryptoScanner scanner = createScanner(mavenProject, Ruleset.BouncyCastle);
 		
-		setErrorsCount("<pattern.AESTest: void testAESEngine2()>", IncompleteOperationError.class, 1);
-		setErrorsCount("<pattern.AESTest: void testAESLightEngine2()>", TypestateError.class, 1);
+		setErrorsCount("<animamea.AmAESCrypto: byte[] getMACOne(byte[])>", ForbiddenMethodError.class, 1);
+		setErrorsCount("<animamea.AmAESCrypto: byte[] getMACTwo(byte[],byte[])>", ForbiddenMethodError.class, 1);
+		setErrorsCount("<animamea.AmAESCrypto: byte[] getMACTwo(byte[],byte[])>", RequiredPredicateError.class, 1);
+		setErrorsCount("<animamea.AmAESCrypto: void <init>()>", RequiredPredicateError.class, 1);
 		
-		// Ignored
-		setErrorsCount("<pattern.AESTest: void testAESEngine1()>", ImpreciseValueExtractionError.class, 2);
-		setErrorsCount("<pattern.AESTest: void testAESEngine2()>", ImpreciseValueExtractionError.class, 1);
-		setErrorsCount("<pattern.AESTest: void testMonteCarloAndVector()>", ImpreciseValueExtractionError.class, 2);
+		setErrorsCount("<gwt_crypto.GMacTest: void performTestOne()>", ForbiddenMethodError.class, 1);
+		setErrorsCount("<gwt_crypto.GMacTest: void performTestOne()>", NeverTypeOfError.class, 2);
+		setErrorsCount("<gwt_crypto.GMacTest: void performTestOne()>", RequiredPredicateError.class, 4);
+		setErrorsCount("<gwt_crypto.GMacTest: void performTestOne()>", IncompleteOperationError.class, 1);
+		setErrorsCount("<gwt_crypto.SkeinMacTest: void performTestOne()>", RequiredPredicateError.class, 1);
+		
+		setErrorsCount("<bunkr.PBKDF2Descriptor: int calculateRounds(int)>", TypestateError.class, 1);
+		setErrorsCount("<bunkr.PBKDF2Descriptor: int calculateRounds(int)>", IncompleteOperationError.class, 2);
+		
+		setErrorsCount("<pattern.MacTest: void testMac1()>", RequiredPredicateError.class, 1);
+		setErrorsCount("<pattern.MacTest: void testMac2()>", RequiredPredicateError.class, 3);
 
 		scanner.exec();
 	  	assertErrors();
@@ -41,6 +51,8 @@ public class BouncyCastleHeadlessTest extends AbstractHeadlessTest {
 		HeadlessCryptoScanner scanner = createScanner(mavenProject, Ruleset.BouncyCastle);
 		
 		setErrorsCount("<gcm_aes_example.GCMAESBouncyCastle: byte[] processing(byte[],boolean)>", RequiredPredicateError.class, 3);
+		setErrorsCount("<gcm_aes_example.GCMAESBouncyCastle: byte[] processingCorrect(byte[],boolean)>", RequiredPredicateError.class, 0);
+		
 		setErrorsCount("<cbc_aes_example.CBCAESBouncyCastle: void setKey(byte[])>", RequiredPredicateError.class, 1);
 		setErrorsCount("<cbc_aes_example.CBCAESBouncyCastle: byte[] processing(byte[],boolean)>", RequiredPredicateError.class, 3);
 
@@ -78,20 +90,25 @@ public class BouncyCastleHeadlessTest extends AbstractHeadlessTest {
 	  	assertErrors();
 	}
 	
-	@Ignore
 	@Test
 	public void testBCDigestExamples() {
 		String mavenProjectPath = new File("../CryptoAnalysisTargets/BCDigestExamples").getAbsolutePath();
 		MavenProject mavenProject = createAndCompile(mavenProjectPath);
 		HeadlessCryptoScanner scanner = createScanner(mavenProject, Ruleset.BouncyCastle);
 		
-		setErrorsCount("<DigestTest: void digestWithoutUpdate()>", TypestateError.class, 1);
+		setErrorsCount("<pattern.DigestTest: void digestWithoutUpdate()>", TypestateError.class, 1);
+		setErrorsCount("<pattern.DigestTest: void digestWithMultipleUpdates()>", TypestateError.class, 1);
 		
-		// False Positives due to issue #129
-		setErrorsCount("<DigestTest: void digestDefaultUsage()>", TypestateError.class, 1);
-		setErrorsCount("<DigestTest: void digestWithMultipleUpdates()>", IncompleteOperationError.class, 1);
-		setErrorsCount("<DigestTest: void multipleDigests()>", IncompleteOperationError.class, 2);
-		setErrorsCount("<DigestTest: void digestWithReset()>", TypestateError.class, 1);
+		setErrorsCount("<inflatable_donkey.KeyBlobCurve25519Unwrap: java.util.Optional unwrapAES(byte[],byte[])>", ForbiddenMethodError.class, 1);
+		setErrorsCount("<inflatable_donkey.KeyBlobCurve25519Unwrap: java.util.Optional unwrapAES(byte[],byte[])>", RequiredPredicateError.class, 1);
+		setErrorsCount("<inflatable_donkey.KeyBlobCurve25519Unwrap: byte[] wrapAES(byte[],byte[])>", ForbiddenMethodError.class, 1);
+		setErrorsCount("<inflatable_donkey.KeyBlobCurve25519Unwrap: byte[] wrapAES(byte[],byte[])>", RequiredPredicateError.class, 1);
+		
+		setErrorsCount("<fabric_api_archieve.Crypto: byte[] sign(byte[],byte[])>", HardCodedError.class, 1);
+		setErrorsCount("<fabric_api_archieve.Crypto: byte[] sign(byte[],byte[])>", RequiredPredicateError.class, 1);
+		
+		setErrorsCount("<pluotsorbet.BouncyCastleSHA256: void TestSHA256DigestOne()>", TypestateError.class, 2);
+		setErrorsCount("<pluotsorbet.BouncyCastleSHA256: void testSHA256DigestTwo()>", TypestateError.class, 3);
 		
 		scanner.exec();
 	  	assertErrors();
@@ -103,6 +120,35 @@ public class BouncyCastleHeadlessTest extends AbstractHeadlessTest {
 		String mavenProjectPath = new File("../CryptoAnalysisTargets/BCSignerExamples").getAbsolutePath();
 		MavenProject mavenProject = createAndCompile(mavenProjectPath);
 		HeadlessCryptoScanner scanner = createScanner(mavenProject, Ruleset.BouncyCastle);
+		
+		setErrorsCount("<org.bouncycastle.crypto.signers.ISO9796d2PSSSigner: void <init>(org.bouncycastle.crypto.AsymmetricBlockCipher,org.bouncycastle.crypto.Digest,int,boolean)>", IncompleteOperationError.class, 2);
+		setErrorsCount("<org.bouncycastle.crypto.signers.ISO9796d2PSSSigner: void updateWithRecoveredMessage(byte[])>", IncompleteOperationError.class, 2);
+		setErrorsCount("<org.bouncycastle.crypto.signers.PSSSigner: void init(boolean,org.bouncycastle.crypto.CipherParameters)>", IncompleteOperationError.class, 2);
+		setErrorsCount("<org.bouncycastle.crypto.signers.PSSSigner: void init(boolean,org.bouncycastle.crypto.CipherParameters)>", RequiredPredicateError.class, 2);
+		setErrorsCount("<org.bouncycastle.crypto.signers.X931Signer: void <init>(org.bouncycastle.crypto.AsymmetricBlockCipher,org.bouncycastle.crypto.Digest,boolean)>", IncompleteOperationError.class, 3);
+		setErrorsCount("<org.bouncycastle.crypto.signers.ISO9796d2Signer: void <init>(org.bouncycastle.crypto.AsymmetricBlockCipher,org.bouncycastle.crypto.Digest,boolean)>", IncompleteOperationError.class, 1);
+		
+		setErrorsCount("<gwt_crypto.ISO9796SignerTest: void doShortPartialTest()>", IncompleteOperationError.class, 1);
+		setErrorsCount("<gwt_crypto.ISO9796SignerTest: void doFullMessageTest()>", HardCodedError.class, 1);
+		setErrorsCount("<gwt_crypto.ISO9796SignerTest: void doFullMessageTest()>", IncompleteOperationError.class, 1);
+		setErrorsCount("<gwt_crypto.PSSBlindTest: void testSig(int,org.bouncycastle.crypto.params.RSAKeyParameters,org.bouncycastle.crypto.params.RSAKeyParameters,byte[],byte[],byte[])>", IncompleteOperationError.class, 1);
+		setErrorsCount("<gwt_crypto.PSSBlindTest: void testSig(int,org.bouncycastle.crypto.params.RSAKeyParameters,org.bouncycastle.crypto.params.RSAKeyParameters,byte[],byte[],byte[])>", RequiredPredicateError.class, 4);
+		setErrorsCount("<gwt_crypto.PSSTest: void testSig(int,org.bouncycastle.crypto.params.RSAKeyParameters,org.bouncycastle.crypto.params.RSAKeyParameters,byte[],byte[],byte[])>", IncompleteOperationError.class, 1);
+		setErrorsCount("<gwt_crypto.PSSTest: void testSig(int,org.bouncycastle.crypto.params.RSAKeyParameters,org.bouncycastle.crypto.params.RSAKeyParameters,byte[],byte[],byte[])>", RequiredPredicateError.class, 2);
+		setErrorsCount("<gwt_crypto.X931SignerTest: void shouldPassSignatureTestOne()>", IncompleteOperationError.class, 1);
+		setErrorsCount("<gwt_crypto.X931SignerTest: void shouldPassSignatureTestTwo()>", RequiredPredicateError.class, 2);
+		setErrorsCount("<gwt_crypto.X931SignerTest: void shouldPassSignatureTestTwo()>", IncompleteOperationError.class, 2);
+		
+		setErrorsCount("<iso9796_signer_verifier.Main: byte[] sign()>", IncompleteOperationError.class, 1);
+		
+		setErrorsCount("<diqube.TicketSignatureService: void signTicket()>", RequiredPredicateError.class, 1);
+		setErrorsCount("<diqube.TicketSignatureService: boolean isValidTicketSignature(byte[])>", RequiredPredicateError.class, 1);
+		
+		setErrorsCount("<bop_bitcoin_client.ECKeyPair: bop_bitcoin_client.ECKeyPair createNew(boolean)>", RequiredPredicateError.class, 3);
+		setErrorsCount("<bop_bitcoin_client.ECKeyPair: byte[] sign(byte[])>", RequiredPredicateError.class, 1);
+		
+		setErrorsCount("<pattern.SignerTest: void testSignerGenerate()>", RequiredPredicateError.class, 3);
+		setErrorsCount("<pattern.SignerTest: void testSignerVerify()>", RequiredPredicateError.class, 3);
 		
 		scanner.exec();
 	  	assertErrors();

--- a/CryptoAnalysis/src/test/java/tests/headless/BragaCryptoGoodusesTest.java
+++ b/CryptoAnalysis/src/test/java/tests/headless/BragaCryptoGoodusesTest.java
@@ -530,7 +530,7 @@ public class BragaCryptoGoodusesTest extends AbstractHeadlessTest {
 		HeadlessCryptoScanner scanner = createScanner(mavenProject);
 
 		setErrorsCount("<example.NonAuthenticatedEphemeralECDH_128: void main(java.lang.String[])>", ConstraintError.class, 0);
-		setErrorsCount("<example.NonAuthenticatedEphemeralECDH_128: void main(java.lang.String[])>", RequiredPredicateError.class, 6);
+		setErrorsCount("<example.NonAuthenticatedEphemeralECDH_128: void main(java.lang.String[])>", RequiredPredicateError.class, 0);
 		
 		setErrorsCount("<example.NonAuthenticatedEphemeralECDH_192: void main(java.lang.String[])>", ConstraintError.class, 2);
 		setErrorsCount("<example.NonAuthenticatedEphemeralECDH_192: void main(java.lang.String[])>", RequiredPredicateError.class, 8);

--- a/CryptoAnalysis/src/test/java/tests/headless/BragaCryptoMisusesTest.java
+++ b/CryptoAnalysis/src/test/java/tests/headless/BragaCryptoMisusesTest.java
@@ -2,7 +2,6 @@ package tests.headless;
 
 import java.io.File;
 
-import org.junit.Ignore;
 import org.junit.Test;
 
 import crypto.HeadlessCryptoScanner;
@@ -578,7 +577,7 @@ public class BragaCryptoMisusesTest extends AbstractHeadlessTest {
 
 		// positive test case
 		setErrorsCount("<pkc.ka.issuesDHandECDH.NonAuthenticatedEphemeralDH_1024: void positiveTestCase()>", ConstraintError.class, 0);
-		setErrorsCount("<pkc.ka.issuesDHandECDH.NonAuthenticatedEphemeralDH_1024: void positiveTestCase()>", RequiredPredicateError.class, 6);
+		setErrorsCount("<pkc.ka.issuesDHandECDH.NonAuthenticatedEphemeralDH_1024: void positiveTestCase()>", RequiredPredicateError.class, 0);
 
 		// negative test case
 		setErrorsCount("<pkc.ka.issuesDHandECDH.NonAuthenticatedEphemeralDH_1024: void negativeTestCase()>", ConstraintError.class, 2);
@@ -702,7 +701,6 @@ public class BragaCryptoMisusesTest extends AbstractHeadlessTest {
 	// This test case corresponds to the following project in BragaCryptoBench:
 	// https://bitbucket.org/alexmbraga/cryptomisuses/src/master/cib/printPrivSecKey/
 	@Test
-	@Ignore
 	public void printPrivSecKeyExamples() {
 		String mavenProjectPath = new File("../CryptoAnalysisTargets/BragaCryptoBench/cryptomisuses/printPrivSecKey").getAbsolutePath();
 		MavenProject mavenProject = createAndCompile(mavenProjectPath);
@@ -718,33 +716,30 @@ public class BragaCryptoMisusesTest extends AbstractHeadlessTest {
 		// positive test case
 		setErrorsCount("<cib.printPrivSecKey.PrintPrivKey1: void positiveTestCase()>", TypestateError.class, 1);
 		setErrorsCount("<cib.printPrivSecKey.PrintPrivKey1: void positiveTestCase()>", ConstraintError.class, 0);
-		setErrorsCount("<cib.printPrivSecKey.PrintPrivKey1: void positiveTestCase()>", RequiredPredicateError.class, 1);
+		setErrorsCount("<cib.printPrivSecKey.PrintPrivKey1: void positiveTestCase()>", RequiredPredicateError.class, 0);
 
 		// negative test case
 		setErrorsCount("<cib.printPrivSecKey.PrintPrivKey1: void negativeTestCase()>", TypestateError.class, 1);
 		setErrorsCount("<cib.printPrivSecKey.PrintPrivKey1: void negativeTestCase()>", ConstraintError.class, 1);
-		setErrorsCount("<cib.printPrivSecKey.PrintPrivKey1: void negativeTestCase()>", RequiredPredicateError.class, 1);
+		setErrorsCount("<cib.printPrivSecKey.PrintPrivKey1: void negativeTestCase()>", RequiredPredicateError.class, 2);
 		
 		setErrorsCount("<cib.printPrivSecKey.PrintSecKey1: void main(java.lang.String[])>", TypestateError.class, 1);
 		
 		// positive test case
-		// TODO This is not right: Rule for PublicKey is missing
-		setErrorsCount("<cib.printPrivSecKey.PrintDHSecret1: void positiveTestCase()>", RequiredPredicateError.class, 6);
+		setErrorsCount("<cib.printPrivSecKey.PrintDHSecret1: void positiveTestCase()>", ConstraintError.class, 0);
+		setErrorsCount("<cib.printPrivSecKey.PrintDHSecret1: void positiveTestCase()>", RequiredPredicateError.class, 0);
 		
 		// negative test case
 		setErrorsCount("<cib.printPrivSecKey.PrintDHSecret1: void negativeTestCase()>", ConstraintError.class, 2);
-		// TODO This is not right: Rule for PublicKey is missing
 		setErrorsCount("<cib.printPrivSecKey.PrintDHSecret1: void negativeTestCase()>", RequiredPredicateError.class, 8);
 
 		// positive test case
-		// TODO This is not right: Rule for PublicKey is missing
-		setErrorsCount("<cib.printPrivSecKey.PrintDHPrivKey1: void positiveTestCase()>", RequiredPredicateError.class, 6);
+		setErrorsCount("<cib.printPrivSecKey.PrintDHPrivKey1: void positiveTestCase()>", ConstraintError.class, 0);
+		setErrorsCount("<cib.printPrivSecKey.PrintDHPrivKey1: void positiveTestCase()>", RequiredPredicateError.class, 0);
 		
 		// negative test case
 		setErrorsCount("<cib.printPrivSecKey.PrintDHPrivKey1: void negativeTestCase()>", ConstraintError.class, 2);
-		// TODO This is not right: Rule for PublicKey is missing
 		setErrorsCount("<cib.printPrivSecKey.PrintDHPrivKey1: void negativeTestCase()>", RequiredPredicateError.class, 8);
-
 
 		scanner.exec();
 		assertErrors();

--- a/CryptoAnalysis/src/test/java/tests/pattern/BouncyCastleTest.java
+++ b/CryptoAnalysis/src/test/java/tests/pattern/BouncyCastleTest.java
@@ -40,12 +40,16 @@ public class BouncyCastleTest extends UsagePatternTestingFramework {
 	public void testEncryptTwo() throws InvalidCipherTextException {
 	    String edgeInput = "ff6f77206973207468652074696d6520666f7220616c6c20676f6f64206d656e";
 	    byte[] data = Hex.decode(edgeInput);
-		RSAKeyParameters pubParameters = new RSAKeyParameters(false, null, null);
+		
+	    RSAKeyParameters pubParameters = new RSAKeyParameters(false, null, null);
+		Assertions.hasEnsuredPredicate(pubParameters);
+		
 		AsymmetricBlockCipher eng = new RSAEngine();
         // missing init()
-//		eng.init(true, pubParameters);
+		// eng.init(true, pubParameters);
         byte[] cipherText = eng.processBlock(data, 0, data.length);
         Assertions.mustNotBeInAcceptingState(eng);
+        Assertions.notHasEnsuredPredicate(cipherText);
 	}
 	
 	
@@ -54,9 +58,11 @@ public class BouncyCastleTest extends UsagePatternTestingFramework {
 		BigInteger mod = new BigInteger("a0b8e8321b041acd40b7", 16);
 		BigInteger pub = new BigInteger("9f0783a49...da", 16);	
 		BigInteger pri = new BigInteger("21231...cda7", 16); 
+		
 		RSAKeyParameters privParameters = new RSAKeyParameters(true, mod, pri); //<--- warning here
 		Assertions.mustBeInAcceptingState(privParameters);
 		Assertions.notHasEnsuredPredicate(privParameters);
+		
 		RSAKeyParameters pubParameters = new RSAKeyParameters(false, mod, pub); //<--- but no warning here
 		Assertions.mustBeInAcceptingState(pubParameters);
 		Assertions.hasEnsuredPredicate(pubParameters);
@@ -65,7 +71,9 @@ public class BouncyCastleTest extends UsagePatternTestingFramework {
 	@Test
 	public void testORingTwoPredicates1() throws GeneralSecurityException {
 		BigInteger mod = new BigInteger("a0b8e8321b041acd40b7", 16);
-		BigInteger pub = new BigInteger("9f0783a49...da", 16);	
+		BigInteger pub = new BigInteger("9f0783a49...da", 16);
+		BigInteger priv = new BigInteger("92e08f83...19", 16);
+		
 		RSAKeyParameters params = new RSAKeyParameters(false, mod, pub);
 		Assertions.mustBeInAcceptingState(params);
 		Assertions.hasEnsuredPredicate(params);
@@ -74,15 +82,16 @@ public class BouncyCastleTest extends UsagePatternTestingFramework {
 		Assertions.mustBeInAcceptingState(randomParam1);
 		Assertions.hasEnsuredPredicate(randomParam1);
 		
-		BigInteger priv = new BigInteger("92e08f83...19", 16);
 		Random randomGenerator = SecureRandom.getInstance("SHA1PRNG");
 		Assertions.mustBeInAcceptingState(randomGenerator);
 		Assertions.hasEnsuredPredicate(randomGenerator);
+		
 		BigInteger p = new BigInteger(1024, randomGenerator);
 		BigInteger q = new BigInteger(1024, randomGenerator);
 		BigInteger pExp = new BigInteger("1d1a2d3ca8...b5", 16);
 		BigInteger qExp = new BigInteger("6c929e4e816...ed", 16);
 		BigInteger crtCoef = new BigInteger("dae7651ee...39", 16);
+		
 		RSAPrivateCrtKeyParameters privParam = new RSAPrivateCrtKeyParameters(mod, pub, priv, p, q, pExp, qExp, crtCoef);
 		Assertions.mustBeInAcceptingState(privParam);
 		Assertions.notHasEnsuredPredicate(privParam); // because p & q are of type BigInteger which cannot ensure randomized predicate
@@ -99,31 +108,33 @@ public class BouncyCastleTest extends UsagePatternTestingFramework {
 		byte[] genSeed = random.generateSeed(128);
 		KeyParameter keyParam = new KeyParameter(genSeed);
 		byte[] nonce = random.generateSeed(128);
+		
 		AEADParameters aeadParam = new AEADParameters(keyParam, 128, nonce);
 		Assertions.hasEnsuredPredicate(aeadParam);
 		Assertions.mustBeInAcceptingState(aeadParam);
-		AESEngine engine = new AESEngine();
-		Assertions.hasEnsuredPredicate(engine);
+		AESEngine engine = (AESEngine) AESEngine.newInstance();
+		Assertions.notHasEnsuredPredicate(engine);
+		
 		byte[] input = new byte[100];
 		byte[] output = new byte[100];
 		
-		GCMBlockCipher cipher1 = new GCMBlockCipher(engine);
+		GCMBlockCipher cipher1 = (GCMBlockCipher) GCMBlockCipher.newInstance(engine);
 		cipher1.init(false, aeadParam);
 		cipher1.processAADBytes(input, 0, input.length);
 		cipher1.doFinal(output, 0);
-		Assertions.hasEnsuredPredicate(cipher1);
-		Assertions.mustBeInAcceptingState(cipher1);
+		Assertions.notHasEnsuredPredicate(cipher1);
+		Assertions.mustNotBeInAcceptingState(cipher1);
 		
 		ParametersWithIV ivParam = new ParametersWithIV(keyParam, genSeed);
 		Assertions.hasEnsuredPredicate(ivParam);
 		Assertions.mustBeInAcceptingState(ivParam);
 		
-		GCMBlockCipher cipher2 = new GCMBlockCipher(engine);
+		GCMBlockCipher cipher2 = (GCMBlockCipher) GCMBlockCipher.newInstance(engine);
 		cipher2.init(false, ivParam);
-//		cipher2.processAADBytes(input, 0, input.length);
-//		cipher2.doFinal(output, 0);
-		Assertions.hasEnsuredPredicate(cipher2);
-		Assertions.mustNotBeInAcceptingState(cipher2);	
+		// cipher2.processAADBytes(input, 0, input.length);
+		// cipher2.doFinal(output, 0);
+		Assertions.notHasEnsuredPredicate(cipher2);
+		Assertions.mustNotBeInAcceptingState(cipher2);
 	}
 	
 	@Test

--- a/CryptoAnalysisTargets/BCMacExamples/src/main/java/gwt_crypto/GMacTest.java
+++ b/CryptoAnalysisTargets/BCMacExamples/src/main/java/gwt_crypto/GMacTest.java
@@ -16,7 +16,7 @@ public class GMacTest {
 		byte[] key = Hex.decode("11754cd72aec309bf52f7687212e8957");
 		byte[] iv = Hex.decode("3c819d9a9bed087615030b65");
 		byte[] tag = Hex.decode("250327c674aaf477aef2675748cf6971");
-		Mac mac = new GMac(new GCMBlockCipher(new AESFastEngine()), tag.length * 8);
+		Mac mac = new GMac(GCMBlockCipher.newInstance(new AESFastEngine()), tag.length * 8);
 		CipherParameters param = new KeyParameter(key);
 		mac.init(new ParametersWithIV(param, iv));
 	}

--- a/CryptoAnalysisTargets/BCSignerExamples/src/main/java/bop_bitcoin_client/ECKeyPair.java
+++ b/CryptoAnalysisTargets/BCSignerExamples/src/main/java/bop_bitcoin_client/ECKeyPair.java
@@ -5,8 +5,6 @@ import java.io.IOException;
 import java.math.BigInteger;
 import java.security.SecureRandom;
 
-import javax.xml.bind.ValidationException;
-
 import org.bouncycastle.asn1.ASN1Integer;
 import org.bouncycastle.asn1.DERSequenceGenerator;
 import org.bouncycastle.asn1.sec.SECNamedCurves;
@@ -29,11 +27,11 @@ public class ECKeyPair {
 	private BigInteger priv;
 	@SuppressWarnings("unused")
 	private byte[] pub;
-	public byte[] sign (byte[] hash) throws ValidationException
+	public byte[] sign (byte[] hash) throws IllegalArgumentException
 	{
 		if ( priv == null )
 		{
-			throw new ValidationException ("Need private key to sign");
+			throw new IllegalArgumentException("Need private key to sign");
 		}
 		ECDSASigner signer = new ECDSASigner (new HMacDSAKCalculator (new SHA256Digest ()));
 		signer.init (true, new ECPrivateKeyParameters (priv, domain));

--- a/CryptoAnalysisTargets/BCSymmetricCipherExamples/src/main/java/cbc_aes_example/CBCAESBouncyCastle.java
+++ b/CryptoAnalysisTargets/BCSymmetricCipherExamples/src/main/java/cbc_aes_example/CBCAESBouncyCastle.java
@@ -16,7 +16,7 @@ import org.bouncycastle.crypto.params.ParametersWithIV;
 // Copied from https://github.com/p120ph37/cbc-aes-example/
 public class CBCAESBouncyCastle {
 
-    private final CBCBlockCipher cbcBlockCipher = new CBCBlockCipher(new AESEngine());
+    private final CBCBlockCipher cbcBlockCipher = (CBCBlockCipher) CBCBlockCipher.newInstance(AESEngine.newInstance());
     private final SecureRandom random = new SecureRandom();
 
     private KeyParameter key;

--- a/CryptoAnalysisTargets/BCSymmetricCipherExamples/src/main/java/gcm_aes_example/GCMAESBouncyCastle.java
+++ b/CryptoAnalysisTargets/BCSymmetricCipherExamples/src/main/java/gcm_aes_example/GCMAESBouncyCastle.java
@@ -20,7 +20,7 @@ public class GCMAESBouncyCastle {
     public byte[] processing(byte[] input, boolean encrypt)
             throws DataLengthException, InvalidCipherTextException {
          byte[] nonce = new byte[16];
-         GCMBlockCipher cipher = new GCMBlockCipher(new AESEngine());
+         GCMBlockCipher cipher = (GCMBlockCipher) GCMBlockCipher.newInstance(AESEngine.newInstance());
          AEADParameters parameters = new AEADParameters(new KeyParameter(key), 0, nonce);
          cipher.init(false, parameters);
 
@@ -40,7 +40,7 @@ public class GCMAESBouncyCastle {
          byte[] keyParam = new byte[16]; 
          secRand.nextBytes(keyParam);
          key = keyParam;
-         GCMBlockCipher cipher = new GCMBlockCipher(new AESEngine());
+         GCMBlockCipher cipher = (GCMBlockCipher) GCMBlockCipher.newInstance(AESEngine.newInstance());
          AEADParameters parameters = new AEADParameters(new KeyParameter(key), 0, nonce);
          cipher.init(false, parameters);
 


### PR DESCRIPTION
-JCA 3.0.2: Rules for PrivateKey and PublicKey were added. This removes some false positives
-BouncyCastle 3.1.0: Some constructors are deprecated -> Update and extend the tests to conform the correct API usages