### PR TITLE
Add subsequent error detection (CC_SUBS)

### DIFF
--- a/CryptoAnalysis/pom.xml
+++ b/CryptoAnalysis/pom.xml
@@ -87,7 +87,7 @@
 								<artifactItem>
 									<groupId>de.darmstadt.tu.crossing</groupId>
 									<artifactId>JavaCryptographicArchitecture</artifactId>
-									<version>3.0.2</version>
+									<version>3.1.0</version>
 									<classifier>ruleset</classifier>
 									<type>zip</type>
 									<overWrite>true</overWrite>
@@ -117,7 +117,7 @@
 								<artifactItem>
 									<groupId>de.paderborn.uni</groupId>
 									<artifactId>BouncyCastle-JCA</artifactId>
-									<version>3.0.2</version>
+									<version>3.1.0</version>
 									<classifier>ruleset</classifier>
 									<type>zip</type>
 									<overWrite>true</overWrite>

--- a/CryptoAnalysis/src/main/java/crypto/analysis/AnalysisSeedWithSpecification.java
+++ b/CryptoAnalysis/src/main/java/crypto/analysis/AnalysisSeedWithSpecification.java
@@ -4,9 +4,11 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -24,18 +26,18 @@ import boomerang.jimple.AllocVal;
 import boomerang.jimple.Statement;
 import boomerang.jimple.Val;
 import boomerang.results.ForwardBoomerangResults;
-import crypto.analysis.errors.ForbiddenPredicateError;
+import crypto.analysis.errors.AbstractError;
 import crypto.analysis.errors.IncompleteOperationError;
 import crypto.analysis.errors.RequiredPredicateError;
 import crypto.analysis.errors.TypestateError;
 import crypto.constraints.ConstraintSolver;
 import crypto.constraints.EvaluableConstraint;
-import crypto.extractparameter.CallSiteWithExtractedValue;
 import crypto.extractparameter.CallSiteWithParamIndex;
 import crypto.extractparameter.ExtractParameterAnalysis;
 import crypto.extractparameter.ExtractedValue;
 import crypto.interfaces.ICrySLPredicateParameter;
 import crypto.interfaces.ISLConstraint;
+import crypto.predicates.PredicateHandler;
 import crypto.rules.CrySLCondPredicate;
 import crypto.rules.CrySLMethod;
 import crypto.rules.CrySLObject;
@@ -75,9 +77,9 @@ public class AnalysisSeedWithSpecification extends IAnalysisSeed {
 	private Collection<EnsuredCrySLPredicate> ensuredPredicates = Sets.newHashSet();
 	private Multimap<Statement, State> typeStateChange = HashMultimap.create();
 	private Collection<EnsuredCrySLPredicate> indirectlyEnsuredPredicates = Sets.newHashSet();
-	private Set<ISLConstraint> missingPredicates = Sets.newHashSet();
+	private Set<HiddenPredicate> hiddenPredicates = Sets.newHashSet();
 	private ConstraintSolver constraintSolver;
-	private boolean internalConstraintSatisfied;
+	private boolean internalConstraintsSatisfied;
 	protected Map<Statement, SootMethod> allCallsOnObject = Maps.newLinkedHashMap();
 	private ExtractParameterAnalysis parameterAnalysis;
 	private Set<ResultsHandler> resultHandlers = Sets.newHashSet();
@@ -123,25 +125,30 @@ public class AnalysisSeedWithSpecification extends IAnalysisSeed {
 			return;
 		allCallsOnObject = results.getInvokedMethodOnInstance();
 		runExtractParameterAnalysis();
-		checkInternalConstraints();
+		this.internalConstraintsSatisfied = checkInternalConstraints();
 
-		// Analysis seed was not analyzed yet -> Activate predicates from other rules
-		activateIndirectlyEnsuredPredicates();
 
 		computeTypestateErrorUnits();
 		computeTypestateErrorsForEndOfObjectLifeTime();
+
+		activateIndirectlyEnsuredPredicates();
+		checkConstraintsAndEnsurePredicates();
 
 		cryptoScanner.getAnalysisListener().onSeedFinished(this, results);
 		cryptoScanner.getAnalysisListener().collectedValues(this, parameterAnalysis.getCollectedValues());
 	}
 
-	private void checkInternalConstraints() {
-		cryptoScanner.getAnalysisListener().beforeConstraintCheck(this);
-		constraintSolver = new ConstraintSolver(this, allCallsOnObject.keySet(), cryptoScanner.getAnalysisListener());
-		cryptoScanner.getAnalysisListener().checkedConstraints(this, constraintSolver.getRelConstraints());
-		internalConstraintSatisfied = (0 == constraintSolver.evaluateRelConstraints());
-		cryptoScanner.getAnalysisListener().afterConstraintCheck(this);
+	public void registerResultsHandler(ResultsHandler handler) {
+		if (results != null) {
+			handler.done(results);
+		} else {
+			resultHandlers.add(handler);
+		}
 	}
+
+	/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+	 *                                Typestate checks                                   *
+	 * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 	private void runTypestateAnalysis() {
 		analysis.run(this);
@@ -153,31 +160,9 @@ public class AnalysisSeedWithSpecification extends IAnalysisSeed {
 		}
 	}
 
-	public void registerResultsHandler(ResultsHandler handler) {
-		if (results != null) {
-			handler.done(results);
-		} else {
-			resultHandlers.add(handler);
-		}
-	}
-
 	private void runExtractParameterAnalysis() {
 		this.parameterAnalysis = new ExtractParameterAnalysis(this.cryptoScanner, allCallsOnObject, spec.getFSM());
 		this.parameterAnalysis.run();
-	}
-	
-	private void activateIndirectlyEnsuredPredicates() {
-		for (Cell<Statement, Val, TransitionFunction> c : results.asStatementValWeightTable().cellSet()) {
-			Collection<? extends State> states = getTargetStates(c.getValue());
-			
-			for (State state : states) {
-				for (EnsuredCrySLPredicate pred : indirectlyEnsuredPredicates) {
-					if (!isPredicateNegatingState(pred.getPredicate(), state, spec.getRule().getNegatedPredicates())) {
-						predicateHandler.addNewPred(this, c.getRowKey(), c.getColumnKey(), pred);
-					}
-				}
-			}
-		}
 	}
 
 	private void computeTypestateErrorUnits() {
@@ -193,7 +178,6 @@ public class AnalysisSeedWithSpecification extends IAnalysisSeed {
 					typeStateChangeAtStatement(curr, newStateAtCurr);
 				}
 			}
-
 		}
 	}
 
@@ -202,26 +186,37 @@ public class AnalysisSeedWithSpecification extends IAnalysisSeed {
 
 		for (Cell<Statement, Val, TransitionFunction> c : endPathOfPropagation.cellSet()) {
 			Set<SootMethod> expectedMethodsToBeCalled = Sets.newHashSet();
+
 			for (ITransition n : c.getValue().values()) {
-				if (n.to() == null)
+				if (n.to() == null) {
 					continue;
-				if (!n.to().isAccepting()) {
-					if (n.to() instanceof WrappedState) {
-						WrappedState wrappedState = (WrappedState) n.to();
-						for (TransitionEdge t : spec.getRule().getUsagePattern().getAllTransitions()) {
-							if (t.getLeft().equals(wrappedState.delegate()) && !t.from().equals(t.to())) {
-								Collection<SootMethod> converted = CrySLMethodToSootMethod.v().convert(t.getLabel());
-								expectedMethodsToBeCalled.addAll(converted);
-							}
-						}
+				}
+
+				if (n.to().isAccepting()) {
+					continue;
+				}
+
+				if (!(n.to() instanceof WrappedState)) {
+					continue;
+				}
+
+				WrappedState wrappedState = (WrappedState) n.to();
+				for (TransitionEdge t : spec.getRule().getUsagePattern().getAllTransitions()) {
+					if (t.getLeft().equals(wrappedState.delegate()) && !t.from().equals(t.to())) {
+						Collection<SootMethod> converted = CrySLMethodToSootMethod.v().convert(t.getLabel());
+						expectedMethodsToBeCalled.addAll(converted);
 					}
 				}
 			}
+
 			if (!expectedMethodsToBeCalled.isEmpty()) {
 				Statement s = c.getRowKey();
 				Val val = c.getColumnKey();
+
 				if (!(s.getUnit().get() instanceof ThrowStmt)) {
-					cryptoScanner.getAnalysisListener().reportError(this, new IncompleteOperationError(s, val, getSpec().getRule(), this, expectedMethodsToBeCalled));
+					IncompleteOperationError incompleteOperationError = new IncompleteOperationError(s, val, getSpec().getRule(), this, expectedMethodsToBeCalled);
+					this.addError(incompleteOperationError);
+					cryptoScanner.getAnalysisListener().reportError(this, incompleteOperationError);
 				}
 			}
 		}
@@ -231,65 +226,138 @@ public class AnalysisSeedWithSpecification extends IAnalysisSeed {
 		if (typeStateChange.put(curr, stateNode)) {
 			if (stateNode instanceof ReportingErrorStateNode) {
 				ReportingErrorStateNode errorStateNode = (ReportingErrorStateNode) stateNode;
-				cryptoScanner.getAnalysisListener().reportError(this, new TypestateError(curr, getSpec().getRule(), this, errorStateNode.getExpectedCalls()));
-			}
-		}
-		onAddedTypestateChange(curr, stateNode);
-	}
 
-	private void onAddedTypestateChange(Statement curr, State stateNode) {
-		for (CrySLPredicate predToBeEnsured : spec.getRule().getPredicates()) {
-			if (predToBeEnsured.isNegated()) {
-				continue;
-			}
-
-			if (isPredicateGeneratingState(predToBeEnsured, stateNode) && !isPredicateNegatingState(predToBeEnsured, stateNode, spec.getRule().getNegatedPredicates())) {
-				ensuresPred(predToBeEnsured, curr, stateNode);
+				TypestateError typestateError = new TypestateError(curr, getSpec().getRule(), this, errorStateNode.getExpectedCalls());
+				this.addError(typestateError);
+				cryptoScanner.getAnalysisListener().reportError(this, typestateError);
 			}
 		}
 	}
 
-	private void ensuresPred(CrySLPredicate predToBeEnsured, Statement currStmt, State stateNode) {
-		if (predToBeEnsured.isNegated()) {
+	/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+	 *                               Predicate checks                                    *
+	 * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+	/**
+	 * Add an ensured predicate to the seed and implicitly rerun all constraint and
+	 * predicate checks
+	 *
+	 * @param ensPred the ensured predicate
+	 */
+	public void addEnsuredPredicate(EnsuredCrySLPredicate ensPred) {
+		// Hidden predicates do not satisfy any constraints
+		if (ensPred instanceof HiddenPredicate) {
+			HiddenPredicate hiddenPredicate = (HiddenPredicate) ensPred;
+			hiddenPredicates.add(hiddenPredicate);
 			return;
 		}
-		boolean satisfiesConstraintSytem = checkConstraintSystem();
-		if(predToBeEnsured.getConstraint().isPresent()) {
-			satisfiesConstraintSytem = !evaluatePredCond(predToBeEnsured);
+
+		// If the predicate was not ensured before, ensure it and check the constraints
+		if (ensuredPredicates.add(ensPred)) {
+			checkConstraintsAndEnsurePredicates();
 		}
-		
-		for (ICrySLPredicateParameter predicateParam : predToBeEnsured.getParameters()) {
+	}
+
+	private void checkConstraintsAndEnsurePredicates() {
+		boolean satisfiesConstraintSystem = isConstraintSystemSatisfied();
+
+		for (CrySLPredicate predToBeEnsured : spec.getRule().getPredicates()) {
+			boolean isPredicateGeneratingStateAvailable = false;
+			for (Entry<Statement, State> entry : typeStateChange.entries()) {
+				State state = entry.getValue();
+
+				// Check, whether the predicate should be generated in state
+				if (!isPredicateGeneratingState(predToBeEnsured, state)) {
+					continue;
+				}
+
+				// Check, whether the predicate is not negated in state
+				if (isPredicateNegatingState(predToBeEnsured, state)) {
+					continue;
+				}
+
+				isPredicateGeneratingStateAvailable = true;
+				EnsuredCrySLPredicate ensPred;
+				if (!satisfiesConstraintSystem && !predToBeEnsured.getConstraint().isPresent()) {
+					// predicate has no condition, but the constraint system is not satisfied
+					ensPred = new HiddenPredicate(predToBeEnsured, parameterAnalysis.getCollectedValues(), this, HiddenPredicate.HiddenPredicateType.ConstraintsAreNotSatisfied);
+				} else if (predToBeEnsured.getConstraint().isPresent() && !isPredConditionSatisfied(predToBeEnsured)) {
+					// predicate has condition, but condition is not satisfied
+					ensPred = new HiddenPredicate(predToBeEnsured, parameterAnalysis.getCollectedValues(), this, HiddenPredicate.HiddenPredicateType.ConditionIsNotSatisfied);
+				} else {
+					// constraints are satisfied and predicate has no condition or the condition is satisfied
+					ensPred = new EnsuredCrySLPredicate(predToBeEnsured, parameterAnalysis.getCollectedValues());
+				}
+				ensurePredicate(ensPred, entry.getKey(), entry.getValue());
+			}
+
+			if (parameterAnalysis != null && !isPredicateGeneratingStateAvailable) {
+				/* The predicate is not ensured in any state. However, we propagate a hidden predicate
+				 * for all typestate changing statements because the predicate could have been ensured
+				 * if a generating state had been reached
+				 */
+				HiddenPredicate hiddenPredicate = new HiddenPredicate(predToBeEnsured, parameterAnalysis.getCollectedValues(), this, HiddenPredicate.HiddenPredicateType.GeneratingStateIsNeverReached);
+
+				for (Entry<Statement, State> entry : typeStateChange.entries()) {
+					ensurePredicate(hiddenPredicate, entry.getKey(), entry.getValue());
+				}
+			}
+		}
+	}
+
+	/**
+	 * Ensure a {@link EnsuredCrySLPredicate}, if all constraints are satisfied, or a {@link HiddenPredicate},
+	 * if any constraint (CONSTRAINTS, ORDER or REQUIRES) is not satisfied, for the given statement.
+	 *
+	 * @param ensuredPred the predicate to be ensured
+	 * @param currStmt the statement before the type change
+	 * @param stateNode the next state after executing {@code currStmt}
+	 */
+	private void ensurePredicate(EnsuredCrySLPredicate ensuredPred, Statement currStmt, State stateNode) {
+		// Check, whether subsequent error detection is enabled
+		if (ensuredPred instanceof HiddenPredicate && !cryptoScanner.isSubsequentErrorDetection()) {
+			return;
+		}
+
+		// TODO only for first parameter?
+		for (ICrySLPredicateParameter predicateParam : ensuredPred.getPredicate().getParameters()) {
 			if (predicateParam.getName().equals("this")) {
-				expectPredicateWhenThisObjectIsInState(stateNode, currStmt, predToBeEnsured, satisfiesConstraintSytem);
+				expectPredicateWhenThisObjectIsInState(ensuredPred, stateNode, currStmt);
 			}
 		}
-		if (currStmt.isCallsite()) {
-			InvokeExpr ie = ((Stmt) currStmt.getUnit().get()).getInvokeExpr();
-			SootMethod invokedMethod = ie.getMethod();
-			Collection<CrySLMethod> convert = CrySLMethodToSootMethod.v().convert(invokedMethod);
 
-			for (CrySLMethod crySLMethod : convert) {
-				Entry<String, String> retObject = crySLMethod.getRetObject();
-				if (!retObject.getKey().equals("_") && currStmt.getUnit().get() instanceof AssignStmt && predicateParameterEquals(predToBeEnsured.getParameters(), retObject.getKey())) {
-					AssignStmt as = (AssignStmt) currStmt.getUnit().get();
-					Value leftOp = as.getLeftOp();
-					AllocVal val = new AllocVal(leftOp, currStmt.getMethod(), as.getRightOp(), new Statement(as, currStmt.getMethod()));
-					expectPredicateOnOtherObject(predToBeEnsured, currStmt, val, satisfiesConstraintSytem);
-				}
-				int i = 0;
-				for (Entry<String, String> p : crySLMethod.getParameters()) {
-					if (predicateParameterEquals(predToBeEnsured.getParameters(), p.getKey())) {
-						Value param = ie.getArg(i);
-						if (param instanceof Local) {
-							Val val = new Val(param, currStmt.getMethod());
-							expectPredicateOnOtherObject(predToBeEnsured, currStmt, val, satisfiesConstraintSytem);
-						}
-					}
-					i++;
-				}
+		// Check, whether the predicate should be ensured on another object
+		if (!currStmt.isCallsite()) {
+			return;
+		}
 
+		if (!currStmt.getUnit().isPresent()) {
+			return;
+		}
+
+		InvokeExpr invokeExpr = currStmt.getUnit().get().getInvokeExpr();
+		SootMethod invokedMethod = invokeExpr.getMethod();
+		Collection<CrySLMethod> convert = CrySLMethodToSootMethod.v().convert(invokedMethod);
+
+		for (CrySLMethod crySLMethod : convert) {
+			Entry<String, String> retObject = crySLMethod.getRetObject();
+			if (!retObject.getKey().equals("_") && currStmt.getUnit().get() instanceof AssignStmt && predicateParameterEquals(ensuredPred.getPredicate().getParameters(), retObject.getKey())) {
+				AssignStmt as = (AssignStmt) currStmt.getUnit().get();
+				Value leftOp = as.getLeftOp();
+				AllocVal val = new AllocVal(leftOp, currStmt.getMethod(), as.getRightOp(), new Statement(as, currStmt.getMethod()));
+				expectPredicateOnOtherObject(ensuredPred, currStmt, val);
 			}
-
+			int i = 0;
+			for (Entry<String, String> p : crySLMethod.getParameters()) {
+				if (predicateParameterEquals(ensuredPred.getPredicate().getParameters(), p.getKey())) {
+					Value param = invokeExpr.getArg(i);
+					if (param instanceof Local) {
+						Val val = new Val(param, currStmt.getMethod());
+						expectPredicateOnOtherObject(ensuredPred, currStmt, val);
+					}
+				}
+				i++;
+			}
 		}
 	}
 
@@ -302,56 +370,21 @@ public class AnalysisSeedWithSpecification extends IAnalysisSeed {
 		return false;
 	}
 
-	private void expectPredicateOnOtherObject(CrySLPredicate predToBeEnsured, Statement currStmt, Val accessGraph, boolean satisfiesConstraintSytem) {
-		// TODO refactor this method.
-		boolean matched = false;
-		EnsuredCrySLPredicate ensuredCrySLPredicate = new EnsuredCrySLPredicate(predToBeEnsured, parameterAnalysis.getCollectedValues());
-		for (ClassSpecification spec : cryptoScanner.getClassSpecifications()) {
-			if (accessGraph.value() == null) {
-				continue;
-			}
-			Type baseType = accessGraph.value().getType();
-			if (baseType instanceof RefType) {
-				RefType refType = (RefType) baseType;
-				if (spec.getRule().getClassName().equals(refType.getSootClass().getName()) || spec.getRule().getClassName().equals(refType.getSootClass().getShortName())) {
-					if (satisfiesConstraintSytem) {
-						AnalysisSeedWithSpecification seed = cryptoScanner.getOrCreateSeedWithSpec(new AnalysisSeedWithSpecification(cryptoScanner, currStmt, accessGraph, spec));
-						matched = true;
-						seed.addEnsuredPredicateFromOtherRule(ensuredCrySLPredicate);
-						cryptoScanner.getPredicateHandler().reportForbiddenPredicate(ensuredCrySLPredicate, currStmt, seed);
-					}
-				}
-			}
-		}
-		if (matched)
-			return;
-		AnalysisSeedWithEnsuredPredicate seed = cryptoScanner.getOrCreateSeed(new Node<Statement, Val>(currStmt, accessGraph));
-		predicateHandler.expectPredicate(seed, currStmt, predToBeEnsured);
-		if (satisfiesConstraintSytem) {
-			seed.addEnsuredPredicate(ensuredCrySLPredicate);
-		} else {
-			missingPredicates.add(new RequiredCrySLPredicate(predToBeEnsured, currStmt));
-		}
-	}
+	/**
+	 * Update the {@link PredicateHandler} to expect the given predicate on this seed, if the seed is in
+	 * the given state. If {@code ensuredPred} is a {@link HiddenPredicate} (i.e. not all constraints are
+	 * satisfied), the {@link PredicateHandler} is able to distinguish the predicates.
+	 *
+	 * @param ensuredPred the predicate to ensure on this seed
+	 * @param stateNode the state, where the predicate is expected to be ensured
+	 * @param currStmt the statement that leads to the state
+	 */
+	private void expectPredicateWhenThisObjectIsInState(EnsuredCrySLPredicate ensuredPred, State stateNode, Statement currStmt) {
+		predicateHandler.expectPredicate(this, currStmt, ensuredPred.getPredicate());
 
-	private void addEnsuredPredicateFromOtherRule(EnsuredCrySLPredicate ensuredCrySLPredicate) {
-		indirectlyEnsuredPredicates.add(ensuredCrySLPredicate);
-		if (results == null) {
-			return;
-		}
-		
-		// Analysis seed was previously analyzed -> Activate predicate from other rule
-		activateIndirectlyEnsuredPredicates();
-	}
-
-	private void expectPredicateWhenThisObjectIsInState(State stateNode, Statement currStmt, CrySLPredicate predToBeEnsured, boolean satisfiesConstraintSytem) {
-		predicateHandler.expectPredicate(this, currStmt, predToBeEnsured);
-
-		if (!satisfiesConstraintSytem)
-			return;
 		for (Cell<Statement, Val, TransitionFunction> e : results.asStatementValWeightTable().cellSet()) {
 			if (containsTargetState(e.getValue(), stateNode)) {
-				predicateHandler.addNewPred(this, e.getRowKey(), e.getColumnKey(), new EnsuredCrySLPredicate(predToBeEnsured, parameterAnalysis.getCollectedValues()));
+				predicateHandler.addNewPred(this, e.getRowKey(), e.getColumnKey(), ensuredPred);
 			}
 		}
 	}
@@ -369,16 +402,226 @@ public class AnalysisSeedWithSpecification extends IAnalysisSeed {
 		return res;
 	}
 
-	private boolean checkConstraintSystem() {
-		cryptoScanner.getAnalysisListener().beforePredicateCheck(this);
-		boolean checkPredicates = checkPredicates();
-		cryptoScanner.getAnalysisListener().afterPredicateCheck(this);
-		if (!checkPredicates)
-			return false;
-		return internalConstraintSatisfied;
+	/**
+	 * Ensure a predicate on another object. The predicate is added to the other seed's ensured predicates
+	 *
+	 * @param ensPred the predicate to ensure
+	 * @param currStmt the statement that ensures the predicate
+	 * @param accessGraph holds the statement and the other seed's type
+	 */
+	private void expectPredicateOnOtherObject(EnsuredCrySLPredicate ensPred, Statement currStmt, Val accessGraph) {
+		boolean specificationExists = false;
+
+		// Check, whether there is a specification (i.e. a CrySL rule) for the target object
+		for (ClassSpecification spec : cryptoScanner.getClassSpecifications()) {
+			if (accessGraph.value() == null) {
+				continue;
+			}
+
+			Type baseType = accessGraph.value().getType();
+			if (!(baseType instanceof RefType)) {
+				continue;
+			}
+
+			// TODO Use refType (return type) or static type?
+			RefType refType = (RefType) baseType;
+			if (spec.getRule().getClassName().equals(refType.getSootClass().getName())) {
+				AnalysisSeedWithSpecification seed = cryptoScanner.getOrCreateSeedWithSpec(new AnalysisSeedWithSpecification(cryptoScanner, currStmt, accessGraph, spec));
+				seed.addEnsuredPredicateFromOtherRule(ensPred);
+				cryptoScanner.getPredicateHandler().reportForbiddenPredicate(ensPred, currStmt, seed);
+
+				specificationExists = true;
+			}
+		}
+
+		// If no specification has been found, create a seed without a specification
+		if (!specificationExists) {
+			AnalysisSeedWithEnsuredPredicate seed = cryptoScanner.getOrCreateSeed(new Node<>(currStmt, accessGraph));
+			predicateHandler.expectPredicate(seed, currStmt, ensPred.getPredicate());
+			seed.addEnsuredPredicate(ensPred);
+		}
 	}
 
-	public boolean checkPredicates() {
+	private void addEnsuredPredicateFromOtherRule(EnsuredCrySLPredicate ensuredCrySLPredicate) {
+		indirectlyEnsuredPredicates.add(ensuredCrySLPredicate);
+		if (results == null) {
+			return;
+		}
+
+		activateIndirectlyEnsuredPredicates();
+	}
+
+	/**
+	 * Activate the predicates that were ensured from other seeds and passed to this seed
+	 */
+	private void activateIndirectlyEnsuredPredicates() {
+		for (EnsuredCrySLPredicate pred : indirectlyEnsuredPredicates) {
+			Collection<ICrySLPredicateParameter> parameters = pred.getPredicate().getParameters();
+			String specName = spec.getRule().getClassName();
+			boolean hasThisParameter = parameters.stream().anyMatch(p -> p instanceof CrySLObject && ((CrySLObject) p).getJavaType().equals(specName));
+
+			if (!hasThisParameter) {
+				continue;
+			}
+
+			/* Replace the original parameter corresponding to this seed with 'this'. For example,
+			 * the KeyGenerator ensures 'generatedKey[key, algorithm]' on a SecretKey 'key'. Therefore,
+			 * the seed for the SecretKey ensures 'generated[this, algorithm]'.
+			 */
+			List<ICrySLPredicateParameter> updatedParams = parameters.stream().map(
+					p -> p instanceof CrySLObject && ((CrySLObject) p).getJavaType().equals(specName) ?
+							new CrySLObject("this", specName) : p).collect(Collectors.toList());
+
+			CrySLPredicate updatedPred = new CrySLPredicate(null, pred.getPredicate().getPredName(), updatedParams, false);
+
+			EnsuredCrySLPredicate predWithThis;
+			if (pred instanceof HiddenPredicate) {
+				HiddenPredicate hiddenPredicate = (HiddenPredicate) pred;
+				predWithThis = new HiddenPredicate(updatedPred, hiddenPredicate.getParametersToValues(), hiddenPredicate.getGeneratingSeed(), hiddenPredicate.getType());
+			} else {
+				predWithThis = new EnsuredCrySLPredicate(updatedPred, pred.getParametersToValues());
+			}
+
+			/* Add the predicate with 'this' to the ensured predicates, check the required predicate constraints
+			 * and ensure it in all accepting states that do not negate it
+			 */
+			addEnsuredPredicate(predWithThis);
+			for (Cell<Statement, Val, TransitionFunction> c : results.asStatementValWeightTable().cellSet()) {
+				Collection<? extends State> states = getTargetStates(c.getValue());
+
+				for (State state : states) {
+					if (isPredicateNegatingState(predWithThis.getPredicate(), state)) {
+						continue;
+					}
+
+					if (state.isAccepting()) {
+						predicateHandler.addNewPred(this, c.getRowKey(), c.getColumnKey(), predWithThis);
+					}
+				}
+			}
+		}
+	}
+
+	private boolean isPredicateGeneratingState(CrySLPredicate ensPred, State stateNode) {
+		// Predicate has a condition, i.e. "after" is specified -> Active predicate for corresponding states
+		if (ensPred instanceof CrySLCondPredicate && isConditionalState(((CrySLCondPredicate) ensPred).getConditionalMethods(), stateNode)) {
+			return true;
+		}
+
+		// If there is no condition, the predicate is activated for all accepting states
+		if (!(ensPred instanceof CrySLCondPredicate) && stateNode.isAccepting()) {
+			return true;
+		}
+
+		return false;
+	}
+
+	private boolean isConditionalState(Set<StateNode> conditionalMethods, State state) {
+		if (conditionalMethods == null)
+			return false;
+		for (StateNode s : conditionalMethods) {
+			if (new WrappedState(s).equals(state)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private boolean isPredicateNegatingState(CrySLPredicate ensPred, State stateNode) {
+		// Check, whether the predicate is negated in the given state
+		for (CrySLPredicate negPred : spec.getRule().getNegatedPredicates()) {
+			// Compare names
+			if (!ensPred.getPredName().equals(negPred.getPredName())) {
+				continue;
+			}
+
+			// Compare parameters
+			if (!doParametersMatch(ensPred, negPred)) {
+				continue;
+			}
+
+			// Negated predicate does not have a condition, i.e. no "after" -> predicate is negated in all states
+			if (!(negPred instanceof CrySLCondPredicate)) {
+				return true;
+			}
+
+			CrySLCondPredicate condNegPred = (CrySLCondPredicate) negPred;
+
+			for (StateNode s : condNegPred.getConditionalMethods()) {
+				if (new WrappedState(s).equals(stateNode)) {
+					return true;
+				}
+			}
+		}
+
+		return false;
+	}
+
+	private boolean doParametersMatch(CrySLPredicate ensPred, CrySLPredicate negPred) {
+		// Compare number of parameters
+		if (!(ensPred.getParameters().size() == negPred.getParameters().size())) {
+			return false;
+		}
+
+		// Compare type of parameters pairwise
+		for (int i = 0; i < ensPred.getParameters().size(); i++) {
+			CrySLObject ensParameter = (CrySLObject) ensPred.getParameters().get(i);
+			CrySLObject negParameter = (CrySLObject) negPred.getParameters().get(i);
+
+			// If "_" is used as a parameter, the type is arbitrary
+			if (ensParameter.getJavaType().equals("null") || negParameter.getJavaType().equals("null")) {
+				continue;
+			}
+
+			if (!ensParameter.getJavaType().equals(negParameter.getJavaType())) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+	 *                                Constraint checks                                  *
+	 * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+	/**
+	 * Check the constraints from the CONSTRAINTS section
+	 */
+	private boolean checkInternalConstraints() {
+		cryptoScanner.getAnalysisListener().beforeConstraintCheck(this);
+		constraintSolver = new ConstraintSolver(this, allCallsOnObject.keySet(), cryptoScanner.getAnalysisListener());
+		cryptoScanner.getAnalysisListener().checkedConstraints(this, constraintSolver.getRelConstraints());
+		boolean constraintsSatisfied = (0 == constraintSolver.evaluateRelConstraints());
+		cryptoScanner.getAnalysisListener().afterConstraintCheck(this);
+
+		return constraintsSatisfied;
+	}
+
+	/**
+	 * Check, whether the internal constraints and predicate constraints are satisfied.
+	 * Requires a previous call to {@link #checkInternalConstraints()}
+	 *
+	 * @return true if all internal and required predicate constraints are satisfied
+	 */
+	private boolean isConstraintSystemSatisfied() {
+		if (internalConstraintsSatisfied) {
+			cryptoScanner.getAnalysisListener().beforePredicateCheck(this);
+			boolean requiredPredicatesEnsured = checkPredicates().isEmpty();
+			cryptoScanner.getAnalysisListener().afterPredicateCheck(this);
+
+			return requiredPredicatesEnsured;
+		}
+		return false;
+	}
+
+	/**
+	 * Check, whether all required predicates are satisfied, and return a set with all predicates that are not
+	 * satisfied. If the set is empty, all required predicate constraints are satisfied.
+	 *
+	 * @return remainingPredicates predicates that are not satisfied
+	 */
+	public Collection<ISLConstraint> checkPredicates() {
 		List<ISLConstraint> requiredPredicates = Lists.newArrayList();
 		for (ISLConstraint con : constraintSolver.getRequiredPredicates()) {
 			if (!ConstraintSolver.predefinedPreds.contains((con instanceof RequiredCrySLPredicate) ? ((RequiredCrySLPredicate) con).getPred().getPredName()
@@ -387,18 +630,20 @@ public class AnalysisSeedWithSpecification extends IAnalysisSeed {
 			}
 		}
 		Set<ISLConstraint> remainingPredicates = Sets.newHashSet(requiredPredicates);
-		missingPredicates.removeAll(remainingPredicates);
 
 		for (ISLConstraint pred : requiredPredicates) {
 			if (pred instanceof RequiredCrySLPredicate) {
 				RequiredCrySLPredicate reqPred = (RequiredCrySLPredicate) pred;
+
 				if (reqPred.getPred().isNegated()) {
 					boolean violated = false;
+
 					for (EnsuredCrySLPredicate ensPred : ensuredPredicates) {
 						if (reqPred.getPred().equals(ensPred.getPredicate()) && doPredsMatch(reqPred.getPred(), ensPred)) {
 							violated = true;
 						}
 					}
+
 					if (!violated) {
 						remainingPredicates.remove(pred);
 					}
@@ -438,27 +683,42 @@ public class AnalysisSeedWithSpecification extends IAnalysisSeed {
 		for (ISLConstraint rem : Lists.newArrayList(remainingPredicates)) {
 			if (rem instanceof RequiredCrySLPredicate) {
 				RequiredCrySLPredicate singlePred = (RequiredCrySLPredicate) rem;
-				if (evaluatePredCond(singlePred.getPred())) {
+				if (isPredConditionSatisfied(singlePred.getPred())) {
 					remainingPredicates.remove(singlePred);
 				}
 			} else if (rem instanceof AlternativeReqPredicate) {
 				List<CrySLPredicate> altPred = ((AlternativeReqPredicate) rem).getAlternatives();
-				if (altPred.parallelStream().anyMatch(e -> evaluatePredCond(e))) {
+				if (altPred.parallelStream().anyMatch(e -> isPredConditionSatisfied(e))) {
 					remainingPredicates.remove(rem);
 				}
 			}
 		}
-
-		this.missingPredicates.addAll(remainingPredicates);
-		return remainingPredicates.isEmpty();
+		return remainingPredicates;
 	}
 
-	private boolean evaluatePredCond(CrySLPredicate pred) {
+	/**
+	 * Check for a predicate A =&gt; B, whether the condition A of B is satisfied
+	 *
+	 * @param pred the predicate to be checked
+	 * @return true if the condition is satisfied
+	 */
+	private boolean isPredConditionSatisfied(CrySLPredicate pred) {
 		return pred.getConstraint().map(conditional -> {
 			EvaluableConstraint evalCons = EvaluableConstraint.getInstance(conditional, constraintSolver);
 			evalCons.evaluate();
 			return evalCons.hasErrors();
 		}).orElse(false);
+	}
+
+	public Collection<AbstractError> retrieveErrorsForPredCondition(CrySLPredicate pred) {
+		// Check, whether the predicate has a condition
+		if (!pred.getConstraint().isPresent()) {
+			return Collections.emptyList();
+		}
+
+		// TODO the condition should be reported itself?
+		ISLConstraint condition = pred.getConstraint().get();
+		return Collections.emptyList();
 	}
 
 	private boolean doPredsMatch(CrySLPredicate pred, EnsuredCrySLPredicate ensPred) {
@@ -505,6 +765,13 @@ public class AnalysisSeedWithSpecification extends IAnalysisSeed {
 			}
 		}
 		return requiredPredicatesExist;
+	}
+
+	public void addHiddenPredicatesToError(RequiredPredicateError reqPredError) {
+		for (CrySLPredicate pred : reqPredError.getContradictedPredicates()) {
+			Collection<HiddenPredicate> hiddenPredicatesEnsuringReqPred = hiddenPredicates.parallelStream().filter(p -> p.getPredicate().equals(pred) && doPredsMatch(pred, p)).collect(Collectors.toList());
+			reqPredError.addHiddenPredicates(hiddenPredicatesEnsuringReqPred);
+		}
 	}
 
 	private Collection<String> retrieveValueFromUnit(CallSiteWithParamIndex cswpi, Collection<ExtractedValue> collection) {
@@ -561,98 +828,12 @@ public class AnalysisSeedWithSpecification extends IAnalysisSeed {
 		return true;
 	}
 
+	/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+	 *                               Additional methods	                                 *
+	 * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
 	public ClassSpecification getSpec() {
 		return spec;
-	}
-
-	public void addEnsuredPredicate(EnsuredCrySLPredicate ensPred) {
-		if (ensuredPredicates.add(ensPred)) {
-			for (Entry<Statement, State> e : typeStateChange.entries())
-				onAddedTypestateChange(e.getKey(), e.getValue());
-		}
-	}
-
-	private boolean isPredicateGeneratingState(CrySLPredicate ensPred, State stateNode) {
-		// Predicate has a condition, i.e. "after" is specified -> Active predicate for corresponding states
-		if (ensPred instanceof CrySLCondPredicate && isConditionalState(((CrySLCondPredicate) ensPred).getConditionalMethods(), stateNode)) {
-			return true;
-		}
-
-		// If there is no condition, the predicate is activated for all accepting states
-		if (!(ensPred instanceof CrySLCondPredicate) && stateNode.isAccepting()) {
-			return true;
-		}
-
-		return false;
-	}
-
-	private boolean isConditionalState(Set<StateNode> conditionalMethods, State state) {
-		if (conditionalMethods == null)
-			return false;
-		for (StateNode s : conditionalMethods) {
-			if (new WrappedState(s).equals(state)) {
-				return true;
-			}
-		}
-		return false;
-	}
-	
-	private boolean isPredicateNegatingState(CrySLPredicate ensPred, State stateNode, List<CrySLPredicate> negatedPredicates) {
-		// Check, whether the predicate is negated in the given state
-		for (CrySLPredicate negPred : negatedPredicates) {
-			// Compare names
-			if (!ensPred.getPredName().equals(negPred.getPredName())) {
-				continue;
-			}
-
-			// Compare parameters
-			if (!doParametersMatch(ensPred, negPred)) {
-				continue;
-			}
-
-			// Negated predicate does not have a condition, i.e. no "after" -> predicate is negated in all states
-			if (!(negPred instanceof CrySLCondPredicate)) {
-				return true;
-			}
-
-			CrySLCondPredicate condNegPred = (CrySLCondPredicate) negPred;
-
-			for (StateNode s : condNegPred.getConditionalMethods()) {
-				if (new WrappedState(s).equals(stateNode)) {
-					return true;
-				}
-			}
-		}
-
-		return false;
-	}
-	
-	private boolean doParametersMatch(CrySLPredicate ensPred, CrySLPredicate negPred) {
-		// Compare number of parameters
-		if (!(ensPred.getParameters().size() == negPred.getParameters().size())) {
-			return false;
-		}
-
-		// Compare type of parameters pairwise
-		for (int i = 0; i < ensPred.getParameters().size(); i++) {
-			CrySLObject ensParameter = (CrySLObject) ensPred.getParameters().get(i);
-			CrySLObject negParameter = (CrySLObject) negPred.getParameters().get(i);
-
-			// If "_" is used as a parameter, the type is arbitrary
-			if (ensParameter.getJavaType().equals("null") || negParameter.getJavaType().equals("null")) {
-				continue;
-			}
-
-			if (!ensParameter.getJavaType().equals(negParameter.getJavaType())) {
-				return false;
-			}
-		}
-
-		return true;
-	}
-
-	public Set<ISLConstraint> getMissingPredicates() {
-		return missingPredicates;
 	}
 
 	public ExtractParameterAnalysis getParameterAnalysis() {

--- a/CryptoAnalysis/src/main/java/crypto/analysis/AnalysisSeedWithSpecification.java
+++ b/CryptoAnalysis/src/main/java/crypto/analysis/AnalysisSeedWithSpecification.java
@@ -127,7 +127,6 @@ public class AnalysisSeedWithSpecification extends IAnalysisSeed {
 		runExtractParameterAnalysis();
 		this.internalConstraintsSatisfied = checkInternalConstraints();
 
-
 		computeTypestateErrorUnits();
 		computeTypestateErrorsForEndOfObjectLifeTime();
 
@@ -314,11 +313,6 @@ public class AnalysisSeedWithSpecification extends IAnalysisSeed {
 	 * @param stateNode the next state after executing {@code currStmt}
 	 */
 	private void ensurePredicate(EnsuredCrySLPredicate ensuredPred, Statement currStmt, State stateNode) {
-		// Check, whether subsequent error detection is enabled
-		if (ensuredPred instanceof HiddenPredicate && !cryptoScanner.isSubsequentErrorDetection()) {
-			return;
-		}
-
 		// TODO only for first parameter?
 		for (ICrySLPredicateParameter predicateParam : ensuredPred.getPredicate().getParameters()) {
 			if (predicateParam.getName().equals("this")) {

--- a/CryptoAnalysis/src/main/java/crypto/analysis/CryptoScanner.java
+++ b/CryptoAnalysis/src/main/java/crypto/analysis/CryptoScanner.java
@@ -220,4 +220,8 @@ public abstract class CryptoScanner {
 	public Collection<String> getIgnoredSections() {
 		return new ArrayList<>();
 	}
+
+	public boolean isSubsequentErrorDetection() {
+		return true;
+	}
 }

--- a/CryptoAnalysis/src/main/java/crypto/analysis/CryptoScanner.java
+++ b/CryptoAnalysis/src/main/java/crypto/analysis/CryptoScanner.java
@@ -220,8 +220,4 @@ public abstract class CryptoScanner {
 	public Collection<String> getIgnoredSections() {
 		return new ArrayList<>();
 	}
-
-	public boolean isSubsequentErrorDetection() {
-		return true;
-	}
 }

--- a/CryptoAnalysis/src/main/java/crypto/analysis/HiddenPredicate.java
+++ b/CryptoAnalysis/src/main/java/crypto/analysis/HiddenPredicate.java
@@ -54,7 +54,7 @@ public class HiddenPredicate extends EnsuredCrySLPredicate {
             case GeneratingStateIsNeverReached:
                 List<AbstractError> typestateErrors = allErrors.stream().filter(e -> (e instanceof IncompleteOperationError || e instanceof TypestateError)).collect(Collectors.toList());
                 if(typestateErrors.isEmpty()) {
-                    // seed object has no typestate errors that might be responsible for this dark predicate
+                    // Seed object has no typestate errors that might be responsible for this hidden predicate
                     // TODO: report new info error type to report,
                     // 		that the seeds object could potentially ensure the missing predicate which might cause further subsequent errors
                     // 		but therefore requires a call to the predicate generating statement
@@ -64,20 +64,20 @@ public class HiddenPredicate extends EnsuredCrySLPredicate {
                 return allErrors;
 
             case ConstraintsAreNotSatisfied:
-                // generating state was reached but constraints are not satisfied
-                // thus, return all constraints & required predicate errors
+                // Generating state was reached but constraints are not satisfied.
+                // Thus, return all constraints & required predicate errors.
                 return allErrors.stream().filter(e -> (e instanceof RequiredPredicateError || e instanceof ConstraintError || e instanceof HardCodedError || e instanceof ImpreciseValueExtractionError || e instanceof InstanceOfError || e instanceof NeverTypeOfError)).collect(Collectors.toList());
             case ConditionIsNotSatisfied:
-                // generating state was reached but the predicates condition is not satisfied
-                // thus, return all errors that causes the condition to be not satisfied
+                // Generating state was reached but the predicates condition is not satisfied.
+                // Thus, return all errors that causes the condition to be not satisfied
                 List<AbstractError> precedingErrors = Lists.newArrayList(generatingSeed.retrieveErrorsForPredCondition(this.getPredicate()));
-                // this method is called from a RequiredPredicateError, that want to retrieve its preceding errors
-                // in this case, preceding errors are not reported yet because the predicate condition wasn't required to be satisfied
-                // because the dark predicate is required to be an ensured predicate, we can assume the condition required to be satisfied.
-                // thus, we report errors all errors that causes the condition to be not satisfied
+                // This method is called from a RequiredPredicateError that wants to retrieve its preceding errors.
+                // In this case, preceding errors are not reported yet because the predicate condition wasn't required to be satisfied.
+                // Since the hidden predicate is required to be an ensured predicate, we can assume the condition required to be satisfied.
+                // Thus, we report all errors that causes the condition to be not satisfied.
                 precedingErrors.forEach(e -> this.generatingSeed.cryptoScanner.getAnalysisListener().reportError(generatingSeed, e));
-                // further, preceding errors can be of type RequiredPredicateError.
-                // thus, we have to recursively map preceding errors for the newly reported errors.
+                // Further, preceding errors can be of type RequiredPredicateError.
+                // Thus, we have to recursively map preceding errors for the newly reported errors.
                 for(AbstractError e: precedingErrors) {
                     if(e instanceof RequiredPredicateError) {
                         ((RequiredPredicateError)e).mapPrecedingErrors();

--- a/CryptoAnalysis/src/main/java/crypto/analysis/HiddenPredicate.java
+++ b/CryptoAnalysis/src/main/java/crypto/analysis/HiddenPredicate.java
@@ -1,0 +1,91 @@
+package crypto.analysis;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Multimap;
+import crypto.analysis.errors.AbstractError;
+import crypto.analysis.errors.ConstraintError;
+import crypto.analysis.errors.HardCodedError;
+import crypto.analysis.errors.ImpreciseValueExtractionError;
+import crypto.analysis.errors.IncompleteOperationError;
+import crypto.analysis.errors.InstanceOfError;
+import crypto.analysis.errors.NeverTypeOfError;
+import crypto.analysis.errors.RequiredPredicateError;
+import crypto.analysis.errors.TypestateError;
+import crypto.extractparameter.CallSiteWithParamIndex;
+import crypto.extractparameter.ExtractedValue;
+import crypto.rules.CrySLPredicate;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class HiddenPredicate extends EnsuredCrySLPredicate {
+
+    private final AnalysisSeedWithSpecification generatingSeed;
+    private final HiddenPredicateType type;
+
+    public HiddenPredicate(CrySLPredicate predicate, Multimap<CallSiteWithParamIndex, ExtractedValue> parametersToValues2, AnalysisSeedWithSpecification generatingSeed, HiddenPredicateType type) {
+        super(predicate, parametersToValues2);
+        this.generatingSeed = generatingSeed;
+        this.type = type;
+    }
+
+    public AnalysisSeedWithSpecification getGeneratingSeed() {
+        return generatingSeed;
+    }
+
+    public enum HiddenPredicateType {
+        GeneratingStateIsNeverReached,
+        ConstraintsAreNotSatisfied,
+        ConditionIsNotSatisfied
+    }
+
+    public HiddenPredicateType getType() {
+        return type;
+    }
+
+    /**
+     * Node: Errors are only in complete count at the end of the analysis.
+     * @return errors list of all preceding errors
+     */
+    public List<AbstractError> getPrecedingErrors(){
+        List<AbstractError> results = Lists.newArrayList();
+        List<AbstractError> allErrors = generatingSeed.getErrors();
+        switch(type) {
+            case GeneratingStateIsNeverReached:
+                List<AbstractError> typestateErrors = allErrors.stream().filter(e -> (e instanceof IncompleteOperationError || e instanceof TypestateError)).collect(Collectors.toList());
+                if(typestateErrors.isEmpty()) {
+                    // seed object has no typestate errors that might be responsible for this dark predicate
+                    // TODO: report new info error type to report,
+                    // 		that the seeds object could potentially ensure the missing predicate which might cause further subsequent errors
+                    // 		but therefore requires a call to the predicate generating statement
+                }
+
+                // TODO: check whether the generating state is not reached due to a typestate error
+                return allErrors;
+
+            case ConstraintsAreNotSatisfied:
+                // generating state was reached but constraints are not satisfied
+                // thus, return all constraints & required predicate errors
+                return allErrors.stream().filter(e -> (e instanceof RequiredPredicateError || e instanceof ConstraintError || e instanceof HardCodedError || e instanceof ImpreciseValueExtractionError || e instanceof InstanceOfError || e instanceof NeverTypeOfError)).collect(Collectors.toList());
+            case ConditionIsNotSatisfied:
+                // generating state was reached but the predicates condition is not satisfied
+                // thus, return all errors that causes the condition to be not satisfied
+                List<AbstractError> precedingErrors = Lists.newArrayList(generatingSeed.retrieveErrorsForPredCondition(this.getPredicate()));
+                // this method is called from a RequiredPredicateError, that want to retrieve its preceding errors
+                // in this case, preceding errors are not reported yet because the predicate condition wasn't required to be satisfied
+                // because the dark predicate is required to be an ensured predicate, we can assume the condition required to be satisfied.
+                // thus, we report errors all errors that causes the condition to be not satisfied
+                precedingErrors.forEach(e -> this.generatingSeed.cryptoScanner.getAnalysisListener().reportError(generatingSeed, e));
+                // further, preceding errors can be of type RequiredPredicateError.
+                // thus, we have to recursively map preceding errors for the newly reported errors.
+                for(AbstractError e: precedingErrors) {
+                    if(e instanceof RequiredPredicateError) {
+                        ((RequiredPredicateError)e).mapPrecedingErrors();
+                    }
+                }
+                return precedingErrors;
+
+        }
+        return results;
+    }
+}

--- a/CryptoAnalysis/src/main/java/crypto/analysis/IAnalysisSeed.java
+++ b/CryptoAnalysis/src/main/java/crypto/analysis/IAnalysisSeed.java
@@ -3,11 +3,14 @@ package crypto.analysis;
 import java.math.BigInteger;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
 
 import boomerang.WeightedForwardQuery;
 import boomerang.jimple.Statement;
 import boomerang.jimple.Val;
+import crypto.analysis.errors.AbstractError;
 import crypto.predicates.PredicateHandler;
 import soot.SootMethod;
 import sync.pds.solver.nodes.Node;
@@ -17,17 +20,27 @@ public abstract class IAnalysisSeed extends WeightedForwardQuery<TransitionFunct
 
 	protected final CryptoScanner cryptoScanner;
 	protected final PredicateHandler predicateHandler;
+	protected final List<AbstractError> errorCollection;
 	private String objectId;
 
 	public IAnalysisSeed(CryptoScanner scanner, Statement stmt, Val fact, TransitionFunction func){
 		super(stmt,fact, func);
 		this.cryptoScanner = scanner;
 		this.predicateHandler = scanner.getPredicateHandler();
+		this.errorCollection = new ArrayList<>();
 	}
 	abstract void execute();
 
 	public SootMethod getMethod(){
 		return stmt().getMethod();
+	}
+
+	public void addError(AbstractError e) {
+		this.errorCollection.add(e);
+	}
+
+	public List<AbstractError> getErrors(){
+		return new ArrayList<>(errorCollection);
 	}
 	
 	public String getObjectId() {

--- a/CryptoAnalysis/src/main/java/crypto/analysis/errors/RequiredPredicateError.java
+++ b/CryptoAnalysis/src/main/java/crypto/analysis/errors/RequiredPredicateError.java
@@ -1,9 +1,12 @@
 package crypto.analysis.errors;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
 
 import boomerang.jimple.Statement;
+import crypto.analysis.HiddenPredicate;
 import crypto.extractparameter.CallSiteWithExtractedValue;
 import crypto.rules.CrySLPredicate;
 import crypto.rules.CrySLRule;
@@ -20,11 +23,25 @@ public class RequiredPredicateError extends AbstractError{
 
 	private List<CrySLPredicate> contradictedPredicate;
 	private CallSiteWithExtractedValue extractedValues;
+	private List<HiddenPredicate> hiddenPredicates;
 
 	public RequiredPredicateError(List<CrySLPredicate> contradictedPredicates, Statement location, CrySLRule rule, CallSiteWithExtractedValue multimap) {
 		super(location, rule);
 		this.contradictedPredicate = contradictedPredicates;
 		this.extractedValues = multimap;
+		this.hiddenPredicates = new ArrayList<>();
+	}
+
+	public void addHiddenPredicates(Collection<HiddenPredicate> hiddenPredicates) {
+		this.hiddenPredicates.addAll(hiddenPredicates);
+	}
+
+	public void mapPrecedingErrors() {
+		for (HiddenPredicate hiddenPredicate : hiddenPredicates) {
+			Collection<AbstractError> precedingErrors = hiddenPredicate.getPrecedingErrors();
+			this.addCausingError(precedingErrors);
+			precedingErrors.forEach(e -> e.addSubsequentError(this));
+		}
 	}
 
 	/**

--- a/CryptoAnalysis/src/main/java/crypto/constraints/ConstraintSolver.java
+++ b/CryptoAnalysis/src/main/java/crypto/constraints/ConstraintSolver.java
@@ -101,6 +101,7 @@ public class ConstraintSolver {
 					break;
 				} else {
 					fail++;
+					this.object.addError(e);
 					getReporter().reportError(getObject(), e);
 				}
 			}
@@ -197,6 +198,11 @@ public class ConstraintSolver {
 					result.add(new RequiredCrySLPredicate(pred, cwpi.stmt()));
 				}
 			}
+		}
+
+		// Extract predicates with 'this' as parameter
+		if (pred.getParameters().stream().anyMatch(param -> param.getName().equals("this"))) {
+			result.add(new RequiredCrySLPredicate(pred, object.stmt()));
 		}
 		
 		return result;

--- a/CryptoAnalysis/src/main/java/crypto/extractparameter/CallSiteWithExtractedValue.java
+++ b/CryptoAnalysis/src/main/java/crypto/extractparameter/CallSiteWithExtractedValue.java
@@ -31,6 +31,8 @@ public class CallSiteWithExtractedValue {
 	public String toString() {
 		String res = "";
 		switch(cs.getIndex()) {
+			case -1:
+				return "Return value";
 			case 0: 
 				res = "First ";
 				break;
@@ -44,7 +46,7 @@ public class CallSiteWithExtractedValue {
 				res = "Fourth ";
 				break;
 			case 4: 
-				res = "Fiveth ";
+				res = "Fifth ";
 				break;
 			case 5: 
 				res = "Sixth ";

--- a/CryptoAnalysis/src/main/java/crypto/predicates/PredicateHandler.java
+++ b/CryptoAnalysis/src/main/java/crypto/predicates/PredicateHandler.java
@@ -298,6 +298,7 @@ public class PredicateHandler {
 			if(!rule.getPredicates().isEmpty()) {
 				for (ISLConstraint cons : rule.getConstraints()) {
 					if (cons instanceof CrySLPredicate && ((CrySLPredicate) cons).isNegated()) {
+						// TODO This is weird; why is it always get(0)?
 						contradictionPairs.add(new SimpleEntry<CrySLPredicate, CrySLPredicate>(rule.getPredicates().get(0), ((CrySLPredicate) cons).setNegated(false)));
 					}
 				}
@@ -311,7 +312,8 @@ public class PredicateHandler {
 				}
 				for (Entry<CrySLPredicate, CrySLPredicate> disPair : contradictionPairs) {
 					if (preds.contains(disPair.getKey().getPredName()) && preds.contains(disPair.getValue().getPredName())) {
-						cryptoScanner.getAnalysisListener().reportError(null, new PredicateContradictionError(generatingPredicateStmt, null, disPair));
+						// TODO Rule should not be null
+						//cryptoScanner.getAnalysisListener().reportError(null, new PredicateContradictionError(generatingPredicateStmt, null, disPair));
 					}
 				}
 			}

--- a/CryptoAnalysis/src/test/java/test/UsagePatternTestingFramework.java
+++ b/CryptoAnalysis/src/test/java/test/UsagePatternTestingFramework.java
@@ -6,6 +6,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import com.google.common.base.Joiner;
 import com.google.common.collect.Lists;
@@ -58,11 +59,14 @@ import soot.Value;
 import soot.jimple.IntConstant;
 import soot.jimple.InvokeExpr;
 import soot.jimple.Stmt;
+import soot.jimple.StringConstant;
 import soot.jimple.toolkits.ide.icfg.JimpleBasedInterproceduralCFG;
+import soot.options.Options;
 import sync.pds.solver.nodes.Node;
 import test.assertions.Assertions;
 import test.assertions.CallToForbiddenMethodAssertion;
 import test.assertions.ConstraintErrorCountAssertion;
+import test.assertions.DependentErrorAssertion;
 import test.assertions.ExtractedValueAssertion;
 import test.assertions.HasEnsuredPredicateAssertion;
 import test.assertions.InAcceptingStateAssertion;
@@ -123,6 +127,13 @@ public abstract class UsagePatternTestingFramework extends AbstractTestingFramew
 							
 							@Override
 							public void reportError(AbstractError error) {
+								for (Assertion a : expectedResults) {
+									if (a instanceof DependentErrorAssertion) {
+										DependentErrorAssertion depErrorAssertion = (DependentErrorAssertion) a;
+										depErrorAssertion.addError(error);
+									}
+								}
+
 								error.accept(new ErrorVisitor() {
 									
 									@Override
@@ -442,22 +453,44 @@ public abstract class UsagePatternTestingFramework extends AbstractTestingFramew
 //				queries.add(new ConstraintViolationAssertion(stmt));
 //			}
 
-			if(invocationName.startsWith("hasEnsuredPredicate")){
+			if (invocationName.startsWith("hasEnsuredPredicate")){
 				Value param = invokeExpr.getArg(0);
 				if (!(param instanceof Local))
 					continue;
 				Local queryVar = (Local) param;
 				Val val = new Val(queryVar, m);
-				queries.add(new HasEnsuredPredicateAssertion(stmt, val));
+
+				if (invokeExpr.getArgCount() == 2) {
+					// predicate name is passed as parameter
+					Value predNameParam = invokeExpr.getArg(1);
+					if (!(predNameParam instanceof StringConstant)) {
+						continue;
+					}
+					String predName = ((StringConstant) predNameParam).value;
+					queries.add(new HasEnsuredPredicateAssertion(stmt, val, predName));
+				} else {
+					queries.add(new HasEnsuredPredicateAssertion(stmt, val));
+				}
 			}
 			
-			if(invocationName.startsWith("notHasEnsuredPredicate")){
+			if (invocationName.startsWith("notHasEnsuredPredicate")) {
 				Value param = invokeExpr.getArg(0);
 				if (!(param instanceof Local))
 					continue;
 				Local queryVar = (Local) param;
 				Val val = new Val(queryVar, m);
-				queries.add(new NotHasEnsuredPredicateAssertion(stmt, val));
+
+				if (invokeExpr.getArgCount() == 2) {
+					// predicate name is passed as parameter
+					Value predNameParam = invokeExpr.getArg(1);
+					if (!(predNameParam instanceof StringConstant)) {
+						continue;
+					}
+					String predName = ((StringConstant) predNameParam).value;
+					queries.add(new NotHasEnsuredPredicateAssertion(stmt, val, predName));
+				} else {
+					queries.add(new NotHasEnsuredPredicateAssertion(stmt, val));
+				}
 			}
 			
 			if(invocationName.startsWith("mustNotBeInAcceptingState")){
@@ -504,6 +537,23 @@ public abstract class UsagePatternTestingFramework extends AbstractTestingFramew
 				IntConstant queryVar = (IntConstant) param;
 				queries.add(new TypestateErrorCountAssertion(queryVar.value));
 			}
+
+			if (invocationName.startsWith("dependentError")) {
+				// extract parameters
+				List<Value> params = invokeExpr.getArgs();
+				if (!params.stream().allMatch(param -> param instanceof IntConstant)) {
+					continue;
+				}
+				int thisErrorID = ((IntConstant) params.remove(0)).value;
+				int[] precedingErrorIDs = params.stream().mapToInt(param -> ((IntConstant) param).value).toArray();
+				for (Unit pred : getPredecessorsNotBenchmark(stmt)) {
+					queries.add(new DependentErrorAssertion((Stmt) pred, thisErrorID, precedingErrorIDs));
+				}
+			}
+
+			// connect DependentErrorAssertions
+			Set<Assertion> depErrors = queries.stream().filter(q -> q instanceof DependentErrorAssertion).collect(Collectors.toSet());
+			depErrors.forEach(ass -> ((DependentErrorAssertion)ass).registerListeners(depErrors));
 		}
 	}
 	private Set<Unit> getPredecessorsNotBenchmark(Stmt stmt) {

--- a/CryptoAnalysis/src/test/java/test/assertions/Assertions.java
+++ b/CryptoAnalysis/src/test/java/test/assertions/Assertions.java
@@ -1,61 +1,50 @@
 package test.assertions;
 
 public class Assertions {
-	public static void assertState(Object o, int state) {
-		
-	}
+
+	public static void assertState(Object o, int state) {}
 	
-	public static void extValue(int pos) {
-		
-	}
+	public static void extValue(int pos) {}
 	
-	public static void assertValue(Object o, Object v) {
-		
-	}
+	public static void assertValue(Object o, Object v) {}
 	
-	public static void mustNotBeInAcceptingState(Object o) {
-		
-	}
+	public static void mustNotBeInAcceptingState(Object o) {}
 	
-	public static void mustBeInAcceptingState(Object o) {
-		
-	}
+	public static void mustBeInAcceptingState(Object o) {}
 	
-	public static void violatedConstraint(Object o) {
-		
-	}
+	public static void violatedConstraint(Object o) {}
 	
-	public static void callToForbiddenMethod() {
-		
-	}
+	public static void callToForbiddenMethod() {}
 
-	public static void hasEnsuredPredicate(Object o) {
-		
-	}
+	public static void hasEnsuredPredicate(Object o) {}
 
-	public static void notHasEnsuredPredicate(Object o){
-		
-	}
+	public static void hasEnsuredPredicate(Object o, String predName) {}
 
-    public static void missingTypestateChange() {
-    }
+	public static void notHasEnsuredPredicate(Object o){}
 
-	public static void noMissingTypestateChange() {
-		
-	}
+	public static void notHasEnsuredPredicate(Object o, String predName) {}
 
-	public static void predicateContradiction() {
-	}
+    public static void missingTypestateChange() {}
 
-	public static void predicateErrors(int i) {
-		
-	}
+	public static void noMissingTypestateChange() {}
 
-	public static void constraintErrors(int i) {
-		
-	}
+	public static void predicateContradiction() {}
 
-	public static void typestateErrors(int i) {
-		
-	}
+	public static void predicateErrors(int i) {}
+
+	public static void constraintErrors(int i) {}
+
+	public static void typestateErrors(int i) {}
+
+	public static void dependentError(int thisErrorNr) {}
+
+	public static void dependentError(int thisErrorNr, int precedingError1) {}
+
+	public static void dependentError(int thisErrorNr, int precedingError1, int precedingError2) {}
+
+	public static void dependentError(int thisErrorNr, int precedingError1, int precedingError2, int precedingError3) {}
+
+	public static void dependentError(int thisErrorNr, int precedingError1, int precedingError2, int precedingError3, int precedingError4) {}
+
+	public static void dependentError(int thisErrorNr, int precedingError1, int precedingError2, int precedingError3, int precedingError4, int precedingError5) {}
 }

--- a/CryptoAnalysis/src/test/java/test/assertions/DependentErrorAssertion.java
+++ b/CryptoAnalysis/src/test/java/test/assertions/DependentErrorAssertion.java
@@ -1,0 +1,78 @@
+package test.assertions;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import crypto.analysis.errors.AbstractError;
+import soot.jimple.Stmt;
+import test.Assertion;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+public class DependentErrorAssertion implements Assertion {
+
+    private final Stmt errorLocation;
+    private final List<AbstractError> extractedErrors = Lists.newArrayList();
+    private final int thisAssertionID;
+    private final int[] precedingAssertionIDs;
+    private final Map<Integer,List<AbstractError>> idToErrors = Maps.newHashMap();
+    private final List<DependentErrorAssertion> listener = Lists.newArrayList();
+
+    public DependentErrorAssertion(Stmt stmt, int thisAssertionID, int... precedingAssertionIDs) {
+        this.errorLocation = stmt;
+        this.thisAssertionID = thisAssertionID;
+        this.precedingAssertionIDs = precedingAssertionIDs;
+    }
+
+    @Override
+    public boolean isSatisfied() {
+        if (extractedErrors.isEmpty()) {
+            return false;
+        }
+
+        nextExtractedError:
+        for (AbstractError e: this.extractedErrors) {
+            for (int id: this.precedingAssertionIDs) {
+                if (!this.idToErrors.containsKey(id) || this.idToErrors.get(id).stream().noneMatch(preceding -> e.getRootErrors().contains(preceding))){
+                    continue nextExtractedError;
+                }
+            }
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public boolean isImprecise() {
+        return false;
+    }
+
+    public void registerListeners(Collection<Assertion> assertions) {
+        assertions.forEach(a -> listener.add((DependentErrorAssertion) a));
+    }
+
+    public void addErrorOfOtherLocations(AbstractError error, int errorNr) {
+        List<AbstractError> errorsWithMatchingId = this.idToErrors.getOrDefault(errorNr, Lists.newArrayList());
+        errorsWithMatchingId.add(error);
+        this.idToErrors.put(errorNr, errorsWithMatchingId);
+    }
+
+    public void addError(AbstractError error) {
+        if (!error.getErrorLocation().getUnit().isPresent()) {
+            return;
+        }
+        if (error.getErrorLocation().getUnit().get() == errorLocation) {
+            extractedErrors.add(error);
+            listener.forEach(a -> a.addErrorOfOtherLocations(error, thisAssertionID));
+        }
+    }
+
+    @Override
+    public String toString() {
+        return extractedErrors.isEmpty()
+                ? "Expected an error @ " + errorLocation + " but found none."
+                : extractedErrors + " @ " + errorLocation + " is not a subsequent error.";
+    }
+
+}

--- a/CryptoAnalysis/src/test/java/test/assertions/HasEnsuredPredicateAssertion.java
+++ b/CryptoAnalysis/src/test/java/test/assertions/HasEnsuredPredicateAssertion.java
@@ -2,6 +2,7 @@ package test.assertions;
 
 import boomerang.jimple.Val;
 import crypto.analysis.EnsuredCrySLPredicate;
+import crypto.analysis.HiddenPredicate;
 import soot.jimple.Stmt;
 import test.Assertion;
 
@@ -10,10 +11,16 @@ public class HasEnsuredPredicateAssertion implements Assertion {
 	private Stmt stmt;
 	private Val val;
 	private boolean satisfied;
+	private String predName;
 
 	public HasEnsuredPredicateAssertion(Stmt stmt,  Val val) {
+		this(stmt, val, null);
+	}
+
+	public HasEnsuredPredicateAssertion(Stmt stmt, Val val, String predName) {
 		this.stmt = stmt;
 		this.val = val;
+		this.predName = predName;
 	}
 	
 	public Val getAccessGraph() {
@@ -36,12 +43,21 @@ public class HasEnsuredPredicateAssertion implements Assertion {
 	}
 
 	public void reported(Val seed, EnsuredCrySLPredicate pred) {
-		if(seed.equals(val))
+		if (!seed.equals(val) || pred instanceof HiddenPredicate) {
+			return;
+		}
+
+		if (predName == null || pred.getPredicate().getPredName().equals(predName)) {
 			satisfied = true;
+		}
 	}
 
 	@Override
 	public String toString() {
-		return "Expected a predicate for "+ val +" @ " + stmt;  
+		if (predName == null) {
+			return "Expected a predicate for "+ val +" @ " + stmt;
+		} else {
+			return "Expected '" + predName + "' ensured on " + val + " @ " + stmt;
+		}
 	}
 }

--- a/CryptoAnalysis/src/test/java/test/assertions/NotHasEnsuredPredicateAssertion.java
+++ b/CryptoAnalysis/src/test/java/test/assertions/NotHasEnsuredPredicateAssertion.java
@@ -2,6 +2,7 @@ package test.assertions;
 
 import boomerang.jimple.Val;
 import crypto.analysis.EnsuredCrySLPredicate;
+import crypto.analysis.HiddenPredicate;
 import soot.jimple.Stmt;
 import test.Assertion;
 
@@ -10,10 +11,16 @@ public class NotHasEnsuredPredicateAssertion implements Assertion {
 	private Stmt stmt;
 	private Val val;
 	private boolean imprecise = false;
+	private String predName;
 
 	public NotHasEnsuredPredicateAssertion(Stmt stmt, Val val) {
+		this(stmt, val, null);
+	}
+
+	public NotHasEnsuredPredicateAssertion(Stmt stmt, Val val, String predName) {
 		this.stmt = stmt;
 		this.val = val;
+		this.predName = predName;
 	}
 	
 	public Val getAccessGraph() {
@@ -36,13 +43,21 @@ public class NotHasEnsuredPredicateAssertion implements Assertion {
 	}
 
 	public void reported(Val value, EnsuredCrySLPredicate pred) {
-		if(value.equals(val)){
+		if (!value.equals(val) || pred instanceof HiddenPredicate) {
+			return;
+		}
+
+		if (predName == null || pred.getPredicate().getPredName().equals(predName)) {
 			imprecise = true;
 		}
 	}
 
 	@Override
 	public String toString() {
-		return "Did not expect a predicate for "+ val +" @ " + stmt;  
+		if (predName == null) {
+			return "Did not expect a predicate for " + val + " @ " + stmt;
+		} else {
+			return "Did not expect '" + predName + "' ensured on " + val + " @ " + stmt;
+		}
 	}
 }

--- a/CryptoAnalysis/src/test/java/tests/custom/predicate/RequiredPredicateWithThisTest.java
+++ b/CryptoAnalysis/src/test/java/tests/custom/predicate/RequiredPredicateWithThisTest.java
@@ -1,0 +1,88 @@
+package tests.custom.predicate;
+
+import crypto.analysis.CrySLRulesetSelector;
+import org.junit.Ignore;
+import org.junit.Test;
+import test.UsagePatternTestingFramework;
+import test.assertions.Assertions;
+
+public class RequiredPredicateWithThisTest extends UsagePatternTestingFramework {
+
+    @Override
+    protected CrySLRulesetSelector.Ruleset getRuleSet() {
+        return CrySLRulesetSelector.Ruleset.CustomRules;
+    }
+
+    @Override
+    protected String getRulesetPath() {
+        return "requiredPredicateWithThis";
+    }
+
+    @Test
+    public void positiveRequiredPredicateWithThis() {
+        Source source = new Source();
+        source.causeConstraintError(false);
+
+        SimpleTarget target = source.generateTarget();
+        target.doNothing();
+        Assertions.hasEnsuredPredicate(target, "generatedTarget");
+
+        UsingTarget usingTarget = new UsingTarget();
+        usingTarget.useTarget(target);
+        Assertions.hasEnsuredPredicate(usingTarget);
+
+        Assertions.predicateErrors(0);
+    }
+
+    @Test
+    public void negativeRequiredPredicateWithThis() {
+        Source source = new Source();
+        source.causeConstraintError(true);
+
+        // No ensured predicate is passed to target -> RequiredPredicateError
+        SimpleTarget target = source.generateTarget();
+        target.doNothing();
+        Assertions.notHasEnsuredPredicate(target);
+
+        // RequiredPredicateError for calling useTarget with insecure target
+        UsingTarget usingTarget = new UsingTarget();
+        usingTarget.useTarget(target);
+        Assertions.notHasEnsuredPredicate(usingTarget);
+
+        Assertions.predicateErrors(2);
+    }
+
+    @Test
+    public void positiveRequiredAlternativePredicateWithThis() {
+        Source source = new Source();
+        source.causeConstraintError(false);
+
+        TargetWithAlternatives target = source.generateTargetWithAlternatives();
+        target.doNothing("Nothing");
+        Assertions.hasEnsuredPredicate(target, "generatedTargetWithAlternatives");
+
+        UsingTarget usingTarget = new UsingTarget();
+        usingTarget.useTarget(target);
+        Assertions.hasEnsuredPredicate(usingTarget);
+
+        Assertions.predicateErrors(0);
+    }
+
+    @Test
+    public void negativeRequiredAlternativePredicateWithThis() {
+        Source source = new Source();
+        source.causeConstraintError(true);
+
+        // No ensured predicate is passed to target -> RequiredPredicateError
+        TargetWithAlternatives target = source.generateTargetWithAlternatives();
+        target.doNothing("Nothing");
+        Assertions.notHasEnsuredPredicate(target);
+
+        // RequiredPredicateError for calling useTarget with insecure target
+        UsingTarget usingTarget = new UsingTarget();
+        usingTarget.useTarget(target);
+        Assertions.notHasEnsuredPredicate(usingTarget);
+
+        Assertions.predicateErrors(2);
+    }
+}

--- a/CryptoAnalysis/src/test/java/tests/custom/predicate/SimpleTarget.java
+++ b/CryptoAnalysis/src/test/java/tests/custom/predicate/SimpleTarget.java
@@ -1,0 +1,6 @@
+package tests.custom.predicate;
+
+public class SimpleTarget {
+
+    public void doNothing() {}
+}

--- a/CryptoAnalysis/src/test/java/tests/custom/predicate/Source.java
+++ b/CryptoAnalysis/src/test/java/tests/custom/predicate/Source.java
@@ -1,0 +1,15 @@
+package tests.custom.predicate;
+
+public class Source {
+
+    public void causeConstraintError(boolean value) {}
+
+    public SimpleTarget generateTarget() {
+        return new SimpleTarget();
+    }
+
+    public TargetWithAlternatives generateTargetWithAlternatives() {
+        return new TargetWithAlternatives();
+    }
+
+}

--- a/CryptoAnalysis/src/test/java/tests/custom/predicate/TargetWithAlternatives.java
+++ b/CryptoAnalysis/src/test/java/tests/custom/predicate/TargetWithAlternatives.java
@@ -1,0 +1,6 @@
+package tests.custom.predicate;
+
+public class TargetWithAlternatives {
+
+    public void doNothing(String word) {}
+}

--- a/CryptoAnalysis/src/test/java/tests/custom/predicate/UsingTarget.java
+++ b/CryptoAnalysis/src/test/java/tests/custom/predicate/UsingTarget.java
@@ -1,0 +1,8 @@
+package tests.custom.predicate;
+
+public class UsingTarget {
+
+    public void useTarget(SimpleTarget target) {}
+    public void useTarget(TargetWithAlternatives target) {}
+
+}

--- a/CryptoAnalysis/src/test/java/tests/headless/AbstractHeadlessTest.java
+++ b/CryptoAnalysis/src/test/java/tests/headless/AbstractHeadlessTest.java
@@ -238,19 +238,23 @@ public abstract class AbstractHeadlessTest {
 	}
 
 	protected void assertErrors() {
+		boolean errorFound = false;
+		StringBuilder builder = new StringBuilder();
 		for (Cell<String, Class<?>, Integer> c : errorMarkerCountPerErrorTypeAndMethod.cellSet()) {
 			Integer value = c.getValue();
 			if (value != 0) {
+				builder.append("\n");
 				if (value > 0) {
-//					System.out.println(
-							throw new RuntimeException(
-									"Found " + value + " too few errors of type " + c.getColumnKey() + " in method " + c.getRowKey());
+					builder.append("\tFound " + value + " too few errors of type " + c.getColumnKey() + " in method " + c.getRowKey());
 				} else {
-//					System.out.println(
-							throw new RuntimeException(
-									"Found " + Math.abs(value) + " too many  errors of type " + c.getColumnKey() + " in method " + c.getRowKey());
+					builder.append("\tFound " + Math.abs(value) + " too many  errors of type " + c.getColumnKey() + " in method " + c.getRowKey());
 				}
+				errorFound = true;
 			}
+		}
+
+		if (errorFound) {
+			throw new RuntimeException("Tests not executed as planned:" + builder);
 		}
 	}
 

--- a/CryptoAnalysis/src/test/java/tests/headless/BragaCryptoGoodusesTest.java
+++ b/CryptoAnalysis/src/test/java/tests/headless/BragaCryptoGoodusesTest.java
@@ -47,7 +47,7 @@ public class BragaCryptoGoodusesTest extends AbstractHeadlessTest {
 		setErrorsCount("<example.DefinedProvider6: void main(java.lang.String[])>", TypestateError.class, 1);
 		setErrorsCount("<example.DefinedProvider7: void main(java.lang.String[])>", ConstraintError.class, 1);
 		setErrorsCount("<example.DefinedProvider7: void main(java.lang.String[])>", IncompleteOperationError.class, 4);
-		setErrorsCount("<example.DefinedProvider7: void main(java.lang.String[])>", RequiredPredicateError.class, 2);
+		setErrorsCount("<example.DefinedProvider7: void main(java.lang.String[])>", RequiredPredicateError.class, 5);
 
 		scanner.exec();
 		assertErrors();
@@ -64,7 +64,7 @@ public class BragaCryptoGoodusesTest extends AbstractHeadlessTest {
 
 		setErrorsCount("<example.PBEwLargeCountAndRandomSalt: void main(java.lang.String[])>", TypestateError.class, 1);
 		setErrorsCount("<example.PBEwLargeCountAndRandomSalt: void main(java.lang.String[])>", ConstraintError.class, 1);
-		setErrorsCount("<example.PBEwLargeCountAndRandomSalt: void main(java.lang.String[])>", RequiredPredicateError.class, 3);
+		setErrorsCount("<example.PBEwLargeCountAndRandomSalt: void main(java.lang.String[])>", RequiredPredicateError.class, 4);
 		setErrorsCount("<example.PBEwLargeCountAndRandomSalt: void main(java.lang.String[])>", ForbiddenMethodError.class, 1);
 		setErrorsCount("<example.DoNotSaveToString: void main(java.lang.String[])>", TypestateError.class, 1);
 		setErrorsCount("<example.GenerateRandomIV: void main(java.lang.String[])>", IncompleteOperationError.class, 4);
@@ -85,7 +85,7 @@ public class BragaCryptoGoodusesTest extends AbstractHeadlessTest {
 		HeadlessCryptoScanner scanner = createScanner(mavenProject);
 
 		setErrorsCount("<example.PBEwParameterPassword: void main(java.lang.String[])>", TypestateError.class, 1);
-		setErrorsCount("<example.PBEwParameterPassword: void main(java.lang.String[])>", RequiredPredicateError.class, 3);
+		setErrorsCount("<example.PBEwParameterPassword: void main(java.lang.String[])>", RequiredPredicateError.class, 4);
 		setErrorsCount("<example.PBEwParameterPassword: void main(java.lang.String[])>", ForbiddenMethodError.class, 1);
 		setErrorsCount("<example.PBEwParameterPassword: void main(java.lang.String[])>", ConstraintError.class, 1);
 
@@ -110,7 +110,7 @@ public class BragaCryptoGoodusesTest extends AbstractHeadlessTest {
 		
 		// negative test case
 		setErrorsCount("<example.UseOAEPForRSA: void negativeTestCase()>", IncompleteOperationError.class, 4);
-		setErrorsCount("<example.UseOAEPForRSA: void negativeTestCase()>", RequiredPredicateError.class, 2);
+		setErrorsCount("<example.UseOAEPForRSA: void negativeTestCase()>", RequiredPredicateError.class, 5);
 		setErrorsCount("<example.UseOAEPForRSA: void negativeTestCase()>", ConstraintError.class, 1);
 		setErrorsCount("<example.UseOAEPForRSA: void negativeTestCase()>", TypestateError.class, 0);
 		
@@ -122,7 +122,7 @@ public class BragaCryptoGoodusesTest extends AbstractHeadlessTest {
 
 		// negative test case
 		setErrorsCount("<example.UsePKCS1ForRSA: void negativeTestCase()>", IncompleteOperationError.class, 4);
-		setErrorsCount("<example.UsePKCS1ForRSA: void negativeTestCase()>", RequiredPredicateError.class, 2);
+		setErrorsCount("<example.UsePKCS1ForRSA: void negativeTestCase()>", RequiredPredicateError.class, 5);
 		setErrorsCount("<example.UsePKCS1ForRSA: void negativeTestCase()>", ConstraintError.class, 1);
 		setErrorsCount("<example.UsePKCS1ForRSA: void negativeTestCase()>", TypestateError.class, 0);
 		
@@ -155,7 +155,7 @@ public class BragaCryptoGoodusesTest extends AbstractHeadlessTest {
 		HeadlessCryptoScanner scanner = createScanner(mavenProject);
 
 		setErrorsCount("<example.UseDynamicKeyFor3DES: void main(java.lang.String[])>", ConstraintError.class, 3);
-		setErrorsCount("<example.UseDynamicKeyFor3DES: void main(java.lang.String[])>", RequiredPredicateError.class, 3);
+		setErrorsCount("<example.UseDynamicKeyFor3DES: void main(java.lang.String[])>", RequiredPredicateError.class, 4);
 		setErrorsCount("<example.UseDynamicKeyFor3DES: void main(java.lang.String[])>", TypestateError.class, 1);
 		setErrorsCount("<example.UseDynamicKeyForAES: void main(java.lang.String[])>", TypestateError.class, 1);
 		
@@ -183,7 +183,7 @@ public class BragaCryptoGoodusesTest extends AbstractHeadlessTest {
 				
 		// negative test case
 		setErrorsCount("<example.SecureConfig112bitsRSA_2048x256_1: void negativeTestCase()>", ConstraintError.class, 1);
-		setErrorsCount("<example.SecureConfig112bitsRSA_2048x256_1: void negativeTestCase()>", RequiredPredicateError.class, 4);
+		setErrorsCount("<example.SecureConfig112bitsRSA_2048x256_1: void negativeTestCase()>", RequiredPredicateError.class, 7);
 		setErrorsCount("<example.SecureConfig112bitsRSA_2048x256_1: void negativeTestCase()>", TypestateError.class, 1);
 		
 		// positive test case
@@ -193,7 +193,7 @@ public class BragaCryptoGoodusesTest extends AbstractHeadlessTest {
 				
 		// negative test case
 		setErrorsCount("<example.SecureConfig112bitsRSA_2048x256_2: void negativeTestCase()>", ConstraintError.class, 1);
-		setErrorsCount("<example.SecureConfig112bitsRSA_2048x256_2: void negativeTestCase()>", RequiredPredicateError.class, 2);
+		setErrorsCount("<example.SecureConfig112bitsRSA_2048x256_2: void negativeTestCase()>", RequiredPredicateError.class, 5);
 		setErrorsCount("<example.SecureConfig112bitsRSA_2048x256_2: void negativeTestCase()>", TypestateError.class, 1);
 		
 		// positive test case
@@ -231,7 +231,7 @@ public class BragaCryptoGoodusesTest extends AbstractHeadlessTest {
 		
 		// negative test case
 		setErrorsCount("<example.SecureConfig192bitsRSA_7680x384_1: void negativeTestCase()>", ConstraintError.class, 1);
-		setErrorsCount("<example.SecureConfig192bitsRSA_7680x384_1: void negativeTestCase()>", RequiredPredicateError.class, 4);
+		setErrorsCount("<example.SecureConfig192bitsRSA_7680x384_1: void negativeTestCase()>", RequiredPredicateError.class, 7);
 		setErrorsCount("<example.SecureConfig192bitsRSA_7680x384_1: void negativeTestCase()>", TypestateError.class, 1);
 		
 		// positive test case
@@ -241,7 +241,7 @@ public class BragaCryptoGoodusesTest extends AbstractHeadlessTest {
 				
 		// negative test case
 		setErrorsCount("<example.SecureConfig192bitsRSA_7680x512_1: void negativeTestCase()>", ConstraintError.class, 1);
-		setErrorsCount("<example.SecureConfig192bitsRSA_7680x512_1: void negativeTestCase()>", RequiredPredicateError.class, 4);
+		setErrorsCount("<example.SecureConfig192bitsRSA_7680x512_1: void negativeTestCase()>", RequiredPredicateError.class, 7);
 		setErrorsCount("<example.SecureConfig192bitsRSA_7680x512_1: void negativeTestCase()>", TypestateError.class, 1);
 
 		scanner.exec();
@@ -257,7 +257,7 @@ public class BragaCryptoGoodusesTest extends AbstractHeadlessTest {
 		MavenProject mavenProject = createAndCompile(mavenProjectPath);
 		HeadlessCryptoScanner scanner = createScanner(mavenProject);
 
-		setErrorsCount("<example.UseQualifiedNameForPBE1: void main(java.lang.String[])>", RequiredPredicateError.class, 3);
+		setErrorsCount("<example.UseQualifiedNameForPBE1: void main(java.lang.String[])>", RequiredPredicateError.class, 4);
 		setErrorsCount("<example.UseQualifiedNameForPBE1: void main(java.lang.String[])>", ForbiddenMethodError.class, 1);
 		setErrorsCount("<example.UseQualifiedNameForPBE1: void main(java.lang.String[])>", TypestateError.class, 1);
 		setErrorsCount("<example.UseQualifiedNameForPBE1: void main(java.lang.String[])>", ConstraintError.class, 1);
@@ -275,7 +275,7 @@ public class BragaCryptoGoodusesTest extends AbstractHeadlessTest {
 
 		// negative test case
 		setErrorsCount("<example.UseQualifiedNameForRSAOAEP: void negativeTestCase()>", TypestateError.class, 1);
-		setErrorsCount("<example.UseQualifiedNameForRSAOAEP: void negativeTestCase()>", RequiredPredicateError.class, 2);
+		setErrorsCount("<example.UseQualifiedNameForRSAOAEP: void negativeTestCase()>", RequiredPredicateError.class, 5);
 		setErrorsCount("<example.UseQualifiedNameForRSAOAEP: void negativeTestCase()>", ConstraintError.class, 1);
 		
 		// positive test case
@@ -285,7 +285,7 @@ public class BragaCryptoGoodusesTest extends AbstractHeadlessTest {
 		
 		// negative test case
 		setErrorsCount("<example.UseQualifiedParamsForRSAOAEP: void negativeTestCase()>", TypestateError.class, 1);
-		setErrorsCount("<example.UseQualifiedParamsForRSAOAEP: void negativeTestCase()>", RequiredPredicateError.class, 4);
+		setErrorsCount("<example.UseQualifiedParamsForRSAOAEP: void negativeTestCase()>", RequiredPredicateError.class, 7);
 		setErrorsCount("<example.UseQualifiedParamsForRSAOAEP: void negativeTestCase()>", ConstraintError.class, 1);
 
 		scanner.exec();
@@ -341,7 +341,7 @@ public class BragaCryptoGoodusesTest extends AbstractHeadlessTest {
 
 		// negative test case
 		setErrorsCount("<example.OAEP_2048x256_1: void negativeTestCase()>", ConstraintError.class, 1);
-		setErrorsCount("<example.OAEP_2048x256_1: void negativeTestCase()>", RequiredPredicateError.class, 4);
+		setErrorsCount("<example.OAEP_2048x256_1: void negativeTestCase()>", RequiredPredicateError.class, 7);
 		setErrorsCount("<example.OAEP_2048x256_1: void negativeTestCase()>", TypestateError.class, 1);
 		
 		// positive test case
@@ -351,7 +351,7 @@ public class BragaCryptoGoodusesTest extends AbstractHeadlessTest {
 
 		// negative test case
 		setErrorsCount("<example.OAEP_2048x256_2: void negativeTestCase()>", ConstraintError.class, 1);
-		setErrorsCount("<example.OAEP_2048x256_2: void negativeTestCase()>", RequiredPredicateError.class, 2);
+		setErrorsCount("<example.OAEP_2048x256_2: void negativeTestCase()>", RequiredPredicateError.class, 5);
 		setErrorsCount("<example.OAEP_2048x256_2: void negativeTestCase()>", TypestateError.class, 1);
 		
 		// positive test case
@@ -361,7 +361,7 @@ public class BragaCryptoGoodusesTest extends AbstractHeadlessTest {
 
 		// negative test case
 		setErrorsCount("<example.OAEP_2048x384_1: void negativeTestCase()>", ConstraintError.class, 1);
-		setErrorsCount("<example.OAEP_2048x384_1: void negativeTestCase()>", RequiredPredicateError.class, 4);
+		setErrorsCount("<example.OAEP_2048x384_1: void negativeTestCase()>", RequiredPredicateError.class, 7);
 		setErrorsCount("<example.OAEP_2048x384_1: void negativeTestCase()>", TypestateError.class, 1);
 
 		// positive test case
@@ -371,7 +371,7 @@ public class BragaCryptoGoodusesTest extends AbstractHeadlessTest {
 
 		// negative test case
 		setErrorsCount("<example.OAEP_2048x384_2: void negativeTestCase()>", ConstraintError.class, 1);
-		setErrorsCount("<example.OAEP_2048x384_2: void negativeTestCase()>", RequiredPredicateError.class, 2);
+		setErrorsCount("<example.OAEP_2048x384_2: void negativeTestCase()>", RequiredPredicateError.class, 5);
 		setErrorsCount("<example.OAEP_2048x384_2: void negativeTestCase()>", TypestateError.class, 1);
 
 		// positive test case
@@ -381,7 +381,7 @@ public class BragaCryptoGoodusesTest extends AbstractHeadlessTest {
 
 		// negative test case
 		setErrorsCount("<example.OAEP_2048x512_1: void negativeTestCase()>", ConstraintError.class, 1);
-		setErrorsCount("<example.OAEP_2048x512_1: void negativeTestCase()>", RequiredPredicateError.class, 4);
+		setErrorsCount("<example.OAEP_2048x512_1: void negativeTestCase()>", RequiredPredicateError.class, 7);
 		setErrorsCount("<example.OAEP_2048x512_1: void negativeTestCase()>", TypestateError.class, 1);
 
 		// positive test case
@@ -391,7 +391,7 @@ public class BragaCryptoGoodusesTest extends AbstractHeadlessTest {
 
 		// negative test case
 		setErrorsCount("<example.OAEP_2048x512_2: void negativeTestCase()>", ConstraintError.class, 1);
-		setErrorsCount("<example.OAEP_2048x512_2: void negativeTestCase()>", RequiredPredicateError.class, 2);
+		setErrorsCount("<example.OAEP_2048x512_2: void negativeTestCase()>", RequiredPredicateError.class, 5);
 		setErrorsCount("<example.OAEP_2048x512_2: void negativeTestCase()>", TypestateError.class, 1);
 
 		scanner.exec();
@@ -414,7 +414,7 @@ public class BragaCryptoGoodusesTest extends AbstractHeadlessTest {
 		// negative test case
 		setErrorsCount("<example.PSSwSHA256Signature: void negativeTestCase()>", TypestateError.class, 1);
 		setErrorsCount("<example.PSSwSHA256Signature: void negativeTestCase()>", ConstraintError.class, 2);
-		setErrorsCount("<example.PSSwSHA256Signature: void negativeTestCase()>", RequiredPredicateError.class, 2);
+		setErrorsCount("<example.PSSwSHA256Signature: void negativeTestCase()>", RequiredPredicateError.class, 5);
 
 		// positive test case
 		setErrorsCount("<example.PSSwSHA384Signature: void positiveTestCase()>", TypestateError.class, 1);
@@ -423,7 +423,7 @@ public class BragaCryptoGoodusesTest extends AbstractHeadlessTest {
 		// negative test case
 		setErrorsCount("<example.PSSwSHA384Signature: void negativeTestCase()>", TypestateError.class, 1);
 		setErrorsCount("<example.PSSwSHA384Signature: void negativeTestCase()>", ConstraintError.class, 2);
-		setErrorsCount("<example.PSSwSHA384Signature: void negativeTestCase()>", RequiredPredicateError.class, 2);
+		setErrorsCount("<example.PSSwSHA384Signature: void negativeTestCase()>", RequiredPredicateError.class, 5);
 
 		// positive test case
 		setErrorsCount("<example.PSSwSHA512Signature: void positiveTestCase()>", TypestateError.class, 1);
@@ -432,7 +432,7 @@ public class BragaCryptoGoodusesTest extends AbstractHeadlessTest {
 		// negative test case
 		setErrorsCount("<example.PSSwSHA512Signature: void negativeTestCase()>", TypestateError.class, 1);
 		setErrorsCount("<example.PSSwSHA512Signature: void negativeTestCase()>", ConstraintError.class, 2);
-		setErrorsCount("<example.PSSwSHA512Signature: void negativeTestCase()>", RequiredPredicateError.class, 2);
+		setErrorsCount("<example.PSSwSHA512Signature: void negativeTestCase()>", RequiredPredicateError.class, 5);
 
 		scanner.exec();
 		assertErrors();
@@ -533,22 +533,23 @@ public class BragaCryptoGoodusesTest extends AbstractHeadlessTest {
 		setErrorsCount("<example.NonAuthenticatedEphemeralECDH_128: void main(java.lang.String[])>", RequiredPredicateError.class, 0);
 		
 		setErrorsCount("<example.NonAuthenticatedEphemeralECDH_192: void main(java.lang.String[])>", ConstraintError.class, 2);
-		setErrorsCount("<example.NonAuthenticatedEphemeralECDH_192: void main(java.lang.String[])>", RequiredPredicateError.class, 8);
+		setErrorsCount("<example.NonAuthenticatedEphemeralECDH_192: void main(java.lang.String[])>", RequiredPredicateError.class, 16);
 		
 		setErrorsCount("<example.NonAuthenticatedEphemeralECDH_256: void main(java.lang.String[])>", ConstraintError.class, 2);
-		setErrorsCount("<example.NonAuthenticatedEphemeralECDH_256: void main(java.lang.String[])>", RequiredPredicateError.class, 8);
+		setErrorsCount("<example.NonAuthenticatedEphemeralECDH_256: void main(java.lang.String[])>", RequiredPredicateError.class, 16);
 
 		setErrorsCount("<example.NonAuthenticatedEphemeralDH_2048: void main(java.lang.String[])>", ConstraintError.class, 2);
-		setErrorsCount("<example.NonAuthenticatedEphemeralDH_2048: void main(java.lang.String[])>", RequiredPredicateError.class, 8);
+		setErrorsCount("<example.NonAuthenticatedEphemeralDH_2048: void main(java.lang.String[])>", RequiredPredicateError.class, 16);
 		
 		// positive test case
 		setErrorsCount("<example.NonAuthenticatedDH_2048: void positiveTestCase()>", ConstraintError.class, 0);
-		setErrorsCount("<example.NonAuthenticatedDH_2048: void positiveTestCase()>", RequiredPredicateError.class, 10);
+		setErrorsCount("<example.NonAuthenticatedDH_2048: void positiveTestCase()>", RequiredPredicateError.class, 18);
 		setErrorsCount("<example.NonAuthenticatedDH_2048: void positiveTestCase()>", IncompleteOperationError.class, 1);
 
 		// negative test case
 		setErrorsCount("<example.NonAuthenticatedDH_2048: void negativeTestCase()>", ConstraintError.class, 1);
-		setErrorsCount("<example.NonAuthenticatedDH_2048: void negativeTestCase()>", RequiredPredicateError.class, 10);
+		setErrorsCount("<example.NonAuthenticatedDH_2048: void negativeTestCase()>", RequiredPredicateError.class, 18);
+		setErrorsCount("<example.NonAuthenticatedDH_2048: void negativeTestCase()>", IncompleteOperationError.class, 1);
 		
 		scanner.exec();
 		assertErrors();
@@ -578,13 +579,13 @@ public class BragaCryptoGoodusesTest extends AbstractHeadlessTest {
 
 		// negative test case
 		setErrorsCount("<example.SUN_112bits_DSA2048wSHA256: void negativeTestCase()>", ConstraintError.class, 1);
-		setErrorsCount("<example.SUN_112bits_DSA2048wSHA256: void negativeTestCase()>", RequiredPredicateError.class, 2);
+		setErrorsCount("<example.SUN_112bits_DSA2048wSHA256: void negativeTestCase()>", RequiredPredicateError.class, 5);
 		
-		setErrorsCount("<example.SUN_112bits_ECDSA224wSHA224: void main(java.lang.String[])>", RequiredPredicateError.class, 2);
+		setErrorsCount("<example.SUN_112bits_ECDSA224wSHA224: void main(java.lang.String[])>", RequiredPredicateError.class, 5);
 		setErrorsCount("<example.SUN_112bits_ECDSA224wSHA224: void main(java.lang.String[])>", ConstraintError.class, 3);
-		setErrorsCount("<example.SUN_192bits_ECDSA384wSHA384: void main(java.lang.String[])>", RequiredPredicateError.class, 2);
+		setErrorsCount("<example.SUN_192bits_ECDSA384wSHA384: void main(java.lang.String[])>", RequiredPredicateError.class, 5);
 		setErrorsCount("<example.SUN_192bits_ECDSA384wSHA384: void main(java.lang.String[])>", ConstraintError.class, 3);
-		setErrorsCount("<example.SUN_256bits_ECDSA571wSHA512: void main(java.lang.String[])>", RequiredPredicateError.class, 2);
+		setErrorsCount("<example.SUN_256bits_ECDSA571wSHA512: void main(java.lang.String[])>", RequiredPredicateError.class, 5);
 		setErrorsCount("<example.SUN_256bits_ECDSA571wSHA512: void main(java.lang.String[])>", ConstraintError.class, 3);
 
 		scanner.exec();
@@ -605,7 +606,7 @@ public class BragaCryptoGoodusesTest extends AbstractHeadlessTest {
 
 		// negative test case
 		setErrorsCount("<example.PKCS1_112bitsSign2048xSHA256_1: void negativeTestCase()>", ConstraintError.class, 1);
-		setErrorsCount("<example.PKCS1_112bitsSign2048xSHA256_1: void negativeTestCase()>", RequiredPredicateError.class, 2);
+		setErrorsCount("<example.PKCS1_112bitsSign2048xSHA256_1: void negativeTestCase()>", RequiredPredicateError.class, 5);
 		setErrorsCount("<example.PKCS1_112bitsSign2048xSHA256_1: void negativeTestCase()>", TypestateError.class, 1);
 		
 		// positive test case
@@ -613,7 +614,7 @@ public class BragaCryptoGoodusesTest extends AbstractHeadlessTest {
 
 		// negative test case
 		setErrorsCount("<example.PKCS1_112bitsSign2048xSHA256_2: void negativeTestCase()>", ConstraintError.class, 1);
-		setErrorsCount("<example.PKCS1_112bitsSign2048xSHA256_2: void negativeTestCase()>", RequiredPredicateError.class, 2);
+		setErrorsCount("<example.PKCS1_112bitsSign2048xSHA256_2: void negativeTestCase()>", RequiredPredicateError.class, 5);
 		setErrorsCount("<example.PKCS1_112bitsSign2048xSHA256_2: void negativeTestCase()>", TypestateError.class, 1);
 		
 		setErrorsCount("<example.PKCS1_128bitsSign3072xSHA256_1: void main(java.lang.String[])>", TypestateError.class, 1);
@@ -621,11 +622,11 @@ public class BragaCryptoGoodusesTest extends AbstractHeadlessTest {
 		setErrorsCount("<example.PKCS1_128bitsSign3072xSHA256_2: void main(java.lang.String[])>", TypestateError.class, 1);
 		
 		setErrorsCount("<example.PKCS1_192bitsSign7680xSHA384_1: void main(java.lang.String[])>", TypestateError.class, 1);
-		setErrorsCount("<example.PKCS1_192bitsSign7680xSHA384_1: void main(java.lang.String[])>", RequiredPredicateError.class, 2);
+		setErrorsCount("<example.PKCS1_192bitsSign7680xSHA384_1: void main(java.lang.String[])>", RequiredPredicateError.class, 5);
 		setErrorsCount("<example.PKCS1_192bitsSign7680xSHA384_1: void main(java.lang.String[])>", ConstraintError.class, 1);
 		
 		setErrorsCount("<example.PKCS1_192bitsSign7680xSHA384_2: void main(java.lang.String[])>", TypestateError.class, 1);
-		setErrorsCount("<example.PKCS1_192bitsSign7680xSHA384_2: void main(java.lang.String[])>", RequiredPredicateError.class, 2);
+		setErrorsCount("<example.PKCS1_192bitsSign7680xSHA384_2: void main(java.lang.String[])>", RequiredPredicateError.class, 5);
 		setErrorsCount("<example.PKCS1_192bitsSign7680xSHA384_2: void main(java.lang.String[])>", ConstraintError.class, 1);
 		
 		// positive test case
@@ -634,7 +635,7 @@ public class BragaCryptoGoodusesTest extends AbstractHeadlessTest {
 
 		// negative test case
 		setErrorsCount("<example.PSS_112bitsSign2048xSHA256_1: void negativeTestCase()>", ConstraintError.class, 2);
-		setErrorsCount("<example.PSS_112bitsSign2048xSHA256_1: void negativeTestCase()>", RequiredPredicateError.class, 2);
+		setErrorsCount("<example.PSS_112bitsSign2048xSHA256_1: void negativeTestCase()>", RequiredPredicateError.class, 5);
 		setErrorsCount("<example.PSS_112bitsSign2048xSHA256_1: void negativeTestCase()>", TypestateError.class, 1);
 		
 		// positive test case
@@ -643,7 +644,7 @@ public class BragaCryptoGoodusesTest extends AbstractHeadlessTest {
 
 		// negative test case
 		setErrorsCount("<example.PSS_112bitsSign2048xSHA256_2: void negativeTestCase()>", ConstraintError.class, 2);
-		setErrorsCount("<example.PSS_112bitsSign2048xSHA256_2: void negativeTestCase()>", RequiredPredicateError.class, 2);
+		setErrorsCount("<example.PSS_112bitsSign2048xSHA256_2: void negativeTestCase()>", RequiredPredicateError.class, 5);
 		setErrorsCount("<example.PSS_112bitsSign2048xSHA256_2: void negativeTestCase()>", TypestateError.class, 1);
 		
 		setErrorsCount("<example.PSS_128bitsSign3072xSHA256_1: void main(java.lang.String[])>", ConstraintError.class, 1);
@@ -653,11 +654,11 @@ public class BragaCryptoGoodusesTest extends AbstractHeadlessTest {
 		setErrorsCount("<example.PSS_128bitsSign3072xSHA256_2: void main(java.lang.String[])>", TypestateError.class, 1);
 		
 		setErrorsCount("<example.PSS_192bitsSign7680xSHA384_1: void main(java.lang.String[])>", TypestateError.class, 1);
-		setErrorsCount("<example.PSS_192bitsSign7680xSHA384_1: void main(java.lang.String[])>", RequiredPredicateError.class, 2);
+		setErrorsCount("<example.PSS_192bitsSign7680xSHA384_1: void main(java.lang.String[])>", RequiredPredicateError.class, 5);
 		setErrorsCount("<example.PSS_192bitsSign7680xSHA384_1: void main(java.lang.String[])>", ConstraintError.class, 2);
 		
 		setErrorsCount("<example.PSS_192bitsSign7680xSHA384_2: void main(java.lang.String[])>", TypestateError.class, 1);
-		setErrorsCount("<example.PSS_192bitsSign7680xSHA384_2: void main(java.lang.String[])>", RequiredPredicateError.class, 2);
+		setErrorsCount("<example.PSS_192bitsSign7680xSHA384_2: void main(java.lang.String[])>", RequiredPredicateError.class, 5);
 		setErrorsCount("<example.PSS_192bitsSign7680xSHA384_2: void main(java.lang.String[])>", ConstraintError.class, 2);
 
 		scanner.exec();
@@ -674,13 +675,13 @@ public class BragaCryptoGoodusesTest extends AbstractHeadlessTest {
 		HeadlessCryptoScanner scanner = createScanner(mavenProject);
 
 		setErrorsCount("<example.DoNotPrintECDHPrivKey1: void main(java.lang.String[])>", ConstraintError.class, 2);
-		setErrorsCount("<example.DoNotPrintECDHPrivKey1: void main(java.lang.String[])>", RequiredPredicateError.class, 8);
+		setErrorsCount("<example.DoNotPrintECDHPrivKey1: void main(java.lang.String[])>", RequiredPredicateError.class, 16);
 		
 		setErrorsCount("<example.DoNotPrintECDHSecret1: void main(java.lang.String[])>", ConstraintError.class, 2);
-		setErrorsCount("<example.DoNotPrintECDHSecret1: void main(java.lang.String[])>", RequiredPredicateError.class, 8);
+		setErrorsCount("<example.DoNotPrintECDHSecret1: void main(java.lang.String[])>", RequiredPredicateError.class, 16);
 		
 		setErrorsCount("<example.DoNotPrintECDSAPrivKey1: void main(java.lang.String[])>", ConstraintError.class, 3);
-		setErrorsCount("<example.DoNotPrintECDSAPrivKey1: void main(java.lang.String[])>", RequiredPredicateError.class, 2);
+		setErrorsCount("<example.DoNotPrintECDSAPrivKey1: void main(java.lang.String[])>", RequiredPredicateError.class, 5);
 		
 		// positive test case
 		setErrorsCount("<example.DoNotPrintPrivKey1: void positiveTestCase()>", ConstraintError.class, 0);
@@ -689,16 +690,16 @@ public class BragaCryptoGoodusesTest extends AbstractHeadlessTest {
 
 		// negative test case
 		setErrorsCount("<example.DoNotPrintPrivKey1: void negativeTestCase()>", ConstraintError.class, 1);
-		setErrorsCount("<example.DoNotPrintPrivKey1: void negativeTestCase()>", RequiredPredicateError.class, 2);
+		setErrorsCount("<example.DoNotPrintPrivKey1: void negativeTestCase()>", RequiredPredicateError.class, 5);
 		setErrorsCount("<example.DoNotPrintPrivKey1: void negativeTestCase()>", TypestateError.class, 1);
 		
 		setErrorsCount("<example.DoNotPrintSecKey1: void main(java.lang.String[])>", TypestateError.class, 1);
 
 		setErrorsCount("<example.DoNotPrintDHSecret1: void main(java.lang.String[])>", ConstraintError.class, 2);
-		setErrorsCount("<example.DoNotPrintDHSecret1: void main(java.lang.String[])>", RequiredPredicateError.class, 8);
+		setErrorsCount("<example.DoNotPrintDHSecret1: void main(java.lang.String[])>", RequiredPredicateError.class, 16);
 
 		setErrorsCount("<example.DoNotPrintDHPrivKey1: void main(java.lang.String[])>", ConstraintError.class, 2);
-		setErrorsCount("<example.DoNotPrintDHPrivKey1: void main(java.lang.String[])>", RequiredPredicateError.class, 8);
+		setErrorsCount("<example.DoNotPrintDHPrivKey1: void main(java.lang.String[])>", RequiredPredicateError.class, 16);
 
 		scanner.exec();
 		assertErrors();
@@ -762,7 +763,7 @@ public class BragaCryptoGoodusesTest extends AbstractHeadlessTest {
 		
 		// negative test case
 		setErrorsCount("<example.SecureConfig112bitsRSA_2048x256_1: void negativeTestCase()>", ConstraintError.class, 1);
-		setErrorsCount("<example.SecureConfig112bitsRSA_2048x256_1: void negativeTestCase()>", RequiredPredicateError.class, 4);
+		setErrorsCount("<example.SecureConfig112bitsRSA_2048x256_1: void negativeTestCase()>", RequiredPredicateError.class, 7);
 		setErrorsCount("<example.SecureConfig112bitsRSA_2048x256_1: void negativeTestCase()>", TypestateError.class, 1);
 		
 		// positive test case
@@ -772,7 +773,7 @@ public class BragaCryptoGoodusesTest extends AbstractHeadlessTest {
 		
 		// negative test case
 		setErrorsCount("<example.SecureConfig112bitsRSA_2048x256_2: void negativeTestCase()>", ConstraintError.class, 1);
-		setErrorsCount("<example.SecureConfig112bitsRSA_2048x256_2: void negativeTestCase()>", RequiredPredicateError.class, 2);
+		setErrorsCount("<example.SecureConfig112bitsRSA_2048x256_2: void negativeTestCase()>", RequiredPredicateError.class, 5);
 		setErrorsCount("<example.SecureConfig112bitsRSA_2048x256_2: void negativeTestCase()>", TypestateError.class, 1);
 		
 		// positive test case
@@ -808,7 +809,7 @@ public class BragaCryptoGoodusesTest extends AbstractHeadlessTest {
 		
 		// negative test case
 		setErrorsCount("<example.SecureConfig192bitsRSA_7680x384_1: void negativeTestCase()>", ConstraintError.class, 1);
-		setErrorsCount("<example.SecureConfig192bitsRSA_7680x384_1: void negativeTestCase()>", RequiredPredicateError.class, 4);
+		setErrorsCount("<example.SecureConfig192bitsRSA_7680x384_1: void negativeTestCase()>", RequiredPredicateError.class, 7);
 		setErrorsCount("<example.SecureConfig192bitsRSA_7680x384_1: void negativeTestCase()>", TypestateError.class, 1);
 		
 		// positive test case
@@ -818,7 +819,7 @@ public class BragaCryptoGoodusesTest extends AbstractHeadlessTest {
 		
 		// negative test case
 		setErrorsCount("<example.SecureConfig192bitsRSA_7680x384_2: void negativeTestCase()>", ConstraintError.class, 1);
-		setErrorsCount("<example.SecureConfig192bitsRSA_7680x384_2: void negativeTestCase()>", RequiredPredicateError.class, 2);
+		setErrorsCount("<example.SecureConfig192bitsRSA_7680x384_2: void negativeTestCase()>", RequiredPredicateError.class, 5);
 		setErrorsCount("<example.SecureConfig192bitsRSA_7680x384_2: void negativeTestCase()>", TypestateError.class, 1);
 		
 		// positive test case
@@ -828,7 +829,7 @@ public class BragaCryptoGoodusesTest extends AbstractHeadlessTest {
 		
 		// negative test case
 		setErrorsCount("<example.SecureConfig192bitsRSA_7680x512_1: void negativeTestCase()>", ConstraintError.class, 1);
-		setErrorsCount("<example.SecureConfig192bitsRSA_7680x512_1: void negativeTestCase()>", RequiredPredicateError.class, 4);
+		setErrorsCount("<example.SecureConfig192bitsRSA_7680x512_1: void negativeTestCase()>", RequiredPredicateError.class, 7);
 		setErrorsCount("<example.SecureConfig192bitsRSA_7680x512_1: void negativeTestCase()>", TypestateError.class, 1);
 		
 		// positive test case
@@ -838,7 +839,7 @@ public class BragaCryptoGoodusesTest extends AbstractHeadlessTest {
 
 		// negative test case
 		setErrorsCount("<example.SecureConfig192bitsRSA_7680x512_2: void negativeTestCase()>", ConstraintError.class, 1);
-		setErrorsCount("<example.SecureConfig192bitsRSA_7680x512_2: void negativeTestCase()>", RequiredPredicateError.class, 2);
+		setErrorsCount("<example.SecureConfig192bitsRSA_7680x512_2: void negativeTestCase()>", RequiredPredicateError.class, 5);
 		setErrorsCount("<example.SecureConfig192bitsRSA_7680x512_2: void negativeTestCase()>", TypestateError.class, 1);
 
 		scanner.exec();
@@ -855,19 +856,19 @@ public class BragaCryptoGoodusesTest extends AbstractHeadlessTest {
 		HeadlessCryptoScanner scanner = createScanner(mavenProject);
 		
 		setErrorsCount("<example.SecureCurve_secp192k1: void negativeTestCase()>", ConstraintError.class, 1);
-		setErrorsCount("<example.SecureCurve_secp192k1: void negativeTestCase()>", RequiredPredicateError.class, 1);
+		setErrorsCount("<example.SecureCurve_secp192k1: void negativeTestCase()>", RequiredPredicateError.class, 2);
 		
 		setErrorsCount("<example.SecureCurve_secp192r1: void negativeTestCase()>", ConstraintError.class, 1);
-		setErrorsCount("<example.SecureCurve_secp192r1: void negativeTestCase()>", RequiredPredicateError.class, 1);
+		setErrorsCount("<example.SecureCurve_secp192r1: void negativeTestCase()>", RequiredPredicateError.class, 2);
 		
 		setErrorsCount("<example.SecureCurve_secp224k1: void negativeTestCase()>", ConstraintError.class, 1);
-		setErrorsCount("<example.SecureCurve_secp224k1: void negativeTestCase()>", RequiredPredicateError.class, 1);
+		setErrorsCount("<example.SecureCurve_secp224k1: void negativeTestCase()>", RequiredPredicateError.class, 2);
 		
 		setErrorsCount("<example.SecureCurve_secp224r1: void main(java.lang.String[])>", ConstraintError.class, 0);
 		setErrorsCount("<example.SecureCurve_secp224r1: void main(java.lang.String[])>", RequiredPredicateError.class, 0);
 		
 		setErrorsCount("<example.SecureCurve_secp256k1: void negativeTestCase()>", ConstraintError.class, 1);
-		setErrorsCount("<example.SecureCurve_secp256k1: void negativeTestCase()>", RequiredPredicateError.class, 1);
+		setErrorsCount("<example.SecureCurve_secp256k1: void negativeTestCase()>", RequiredPredicateError.class, 2);
 		
 		setErrorsCount("<example.SecureCurve_secp256r1: void main(java.lang.String[])>", ConstraintError.class, 0);
 		setErrorsCount("<example.SecureCurve_secp256r1: void main(java.lang.String[])>", RequiredPredicateError.class, 0);
@@ -879,40 +880,40 @@ public class BragaCryptoGoodusesTest extends AbstractHeadlessTest {
 		setErrorsCount("<example.SecureCurve_secp521r1: void main(java.lang.String[])>", RequiredPredicateError.class, 0);
 
 		setErrorsCount("<example.SecureCurve_sect163k1: void negativeTestCase()>", ConstraintError.class, 1);
-		setErrorsCount("<example.SecureCurve_sect163k1: void negativeTestCase()>", RequiredPredicateError.class, 1);
+		setErrorsCount("<example.SecureCurve_sect163k1: void negativeTestCase()>", RequiredPredicateError.class, 2);
 
 		setErrorsCount("<example.SecureCurve_sect163r1: void negativeTestCase()>", ConstraintError.class, 1);
-		setErrorsCount("<example.SecureCurve_sect163r1: void negativeTestCase()>", RequiredPredicateError.class, 1);
+		setErrorsCount("<example.SecureCurve_sect163r1: void negativeTestCase()>", RequiredPredicateError.class, 2);
 
 		setErrorsCount("<example.SecureCurve_sect163r2: void negativeTestCase()>", ConstraintError.class, 1);
-		setErrorsCount("<example.SecureCurve_sect163r2: void negativeTestCase()>", RequiredPredicateError.class, 1);
+		setErrorsCount("<example.SecureCurve_sect163r2: void negativeTestCase()>", RequiredPredicateError.class, 2);
 
 		setErrorsCount("<example.SecureCurve_sect233k1: void negativeTestCase()>", ConstraintError.class, 1);
-		setErrorsCount("<example.SecureCurve_sect233k1: void negativeTestCase()>", RequiredPredicateError.class, 1);
+		setErrorsCount("<example.SecureCurve_sect233k1: void negativeTestCase()>", RequiredPredicateError.class, 2);
 
 		setErrorsCount("<example.SecureCurve_sect233r1: void negativeTestCase()>", ConstraintError.class, 1);
-		setErrorsCount("<example.SecureCurve_sect233r1: void negativeTestCase()>", RequiredPredicateError.class, 1);
+		setErrorsCount("<example.SecureCurve_sect233r1: void negativeTestCase()>", RequiredPredicateError.class, 2);
 
 		setErrorsCount("<example.SecureCurve_sect239k1: void negativeTestCase()>", ConstraintError.class, 1);
-		setErrorsCount("<example.SecureCurve_sect239k1: void negativeTestCase()>", RequiredPredicateError.class, 1);
+		setErrorsCount("<example.SecureCurve_sect239k1: void negativeTestCase()>", RequiredPredicateError.class, 2);
 
 		setErrorsCount("<example.SecureCurve_sect283k1: void negativeTestCase()>", ConstraintError.class, 1);
-		setErrorsCount("<example.SecureCurve_sect283k1: void negativeTestCase()>", RequiredPredicateError.class, 1);
+		setErrorsCount("<example.SecureCurve_sect283k1: void negativeTestCase()>", RequiredPredicateError.class, 2);
 
 		setErrorsCount("<example.SecureCurve_sect283r1: void negativeTestCase()>", ConstraintError.class, 1);
-		setErrorsCount("<example.SecureCurve_sect283r1: void negativeTestCase()>", RequiredPredicateError.class, 1);
+		setErrorsCount("<example.SecureCurve_sect283r1: void negativeTestCase()>", RequiredPredicateError.class, 2);
 
 		setErrorsCount("<example.SecureCurve_sect409k1: void negativeTestCase()>", ConstraintError.class, 1);
-		setErrorsCount("<example.SecureCurve_sect409k1: void negativeTestCase()>", RequiredPredicateError.class, 1);
+		setErrorsCount("<example.SecureCurve_sect409k1: void negativeTestCase()>", RequiredPredicateError.class, 2);
 
 		setErrorsCount("<example.SecureCurve_sect409r1: void negativeTestCase()>", ConstraintError.class, 1);
-		setErrorsCount("<example.SecureCurve_sect409r1: void negativeTestCase()>", RequiredPredicateError.class, 1);
+		setErrorsCount("<example.SecureCurve_sect409r1: void negativeTestCase()>", RequiredPredicateError.class, 2);
 
 		setErrorsCount("<example.SecureCurve_sect571k1: void negativeTestCase()>", ConstraintError.class, 1);
-		setErrorsCount("<example.SecureCurve_sect571k1: void negativeTestCase()>", RequiredPredicateError.class, 1);
+		setErrorsCount("<example.SecureCurve_sect571k1: void negativeTestCase()>", RequiredPredicateError.class, 2);
 
 		setErrorsCount("<example.SecureCurve_sect571r1: void negativeTestCase()>", ConstraintError.class, 1);
-		setErrorsCount("<example.SecureCurve_sect571r1: void negativeTestCase()>", RequiredPredicateError.class, 1);
+		setErrorsCount("<example.SecureCurve_sect571r1: void negativeTestCase()>", RequiredPredicateError.class, 2);
 
 		scanner.exec();
 		assertErrors();

--- a/CryptoAnalysis/src/test/java/tests/headless/BragaCryptoMisusesTest.java
+++ b/CryptoAnalysis/src/test/java/tests/headless/BragaCryptoMisusesTest.java
@@ -56,13 +56,13 @@ public class BragaCryptoMisusesTest extends AbstractHeadlessTest {
 		HeadlessCryptoScanner scanner = createScanner(mavenProject);
 
 		setErrorsCount("<wc.brokenInsecureMAC.InsecureMAC1: void main(java.lang.String[])>", ConstraintError.class, 8);
-		setErrorsCount("<wc.brokenInsecureMAC.InsecureMAC1: void main(java.lang.String[])>", RequiredPredicateError.class, 6);
+		setErrorsCount("<wc.brokenInsecureMAC.InsecureMAC1: void main(java.lang.String[])>", RequiredPredicateError.class, 8);
 		// setErrorsCount("<wc.brokenInsecureMAC.InsecureMAC2: void main(java.lang.String[])>", ConstraintError.class, 8);
 		// setErrorsCount("<wc.brokenInsecureMAC.InsecureMAC2: void main(java.lang.String[])>", RequiredPredicateError.class, 6);
 		setErrorsCount("<wc.brokenInsecureMAC.InsecureMAC3: void main(java.lang.String[])>", ConstraintError.class, 4);
-		setErrorsCount("<wc.brokenInsecureMAC.InsecureMAC3: void main(java.lang.String[])>", RequiredPredicateError.class, 3);
+		setErrorsCount("<wc.brokenInsecureMAC.InsecureMAC3: void main(java.lang.String[])>", RequiredPredicateError.class, 4);
 		setErrorsCount("<wc.brokenInsecureMAC.InsecureMAC4: void main(java.lang.String[])>", ConstraintError.class, 4);
-		setErrorsCount("<wc.brokenInsecureMAC.InsecureMAC4: void main(java.lang.String[])>", RequiredPredicateError.class, 3);
+		setErrorsCount("<wc.brokenInsecureMAC.InsecureMAC4: void main(java.lang.String[])>", RequiredPredicateError.class, 4);
 
 		scanner.exec();
 		assertErrors();
@@ -140,7 +140,7 @@ public class BragaCryptoMisusesTest extends AbstractHeadlessTest {
 		MavenProject mavenProject = createAndCompile(mavenProjectPath);
 		HeadlessCryptoScanner scanner = createScanner(mavenProject);
 
-		setErrorsCount("<pkm.constantKey.ConstantKey3DES: void main(java.lang.String[])>", RequiredPredicateError.class, 3);
+		setErrorsCount("<pkm.constantKey.ConstantKey3DES: void main(java.lang.String[])>", RequiredPredicateError.class, 4);
 		setErrorsCount("<pkm.constantKey.ConstantKey3DES: void main(java.lang.String[])>", ConstraintError.class, 2);
 		setErrorsCount("<pkm.constantKey.ConstantKey3DES: void main(java.lang.String[])>", TypestateError.class, 1);
 		setErrorsCount("<pkm.constantKey.ConstantKeyAES1: void main(java.lang.String[])>", RequiredPredicateError.class, 3);
@@ -165,12 +165,12 @@ public class BragaCryptoMisusesTest extends AbstractHeadlessTest {
 		MavenProject mavenProject = createAndCompile(mavenProjectPath);
 		HeadlessCryptoScanner scanner = createScanner(mavenProject);
 
-		setErrorsCount("<pkm.constPwd4PBE.ConstPassword4PBE1: void main(java.lang.String[])>", RequiredPredicateError.class, 3);
+		setErrorsCount("<pkm.constPwd4PBE.ConstPassword4PBE1: void main(java.lang.String[])>", RequiredPredicateError.class, 4);
 		setErrorsCount("<pkm.constPwd4PBE.ConstPassword4PBE1: void main(java.lang.String[])>", ConstraintError.class, 2);
 		setErrorsCount("<pkm.constPwd4PBE.ConstPassword4PBE1: void main(java.lang.String[])>", TypestateError.class, 1);
 		setErrorsCount("<pkm.constPwd4PBE.ConstPassword4PBE1: void main(java.lang.String[])>", ForbiddenMethodError.class, 1);
 		
-		setErrorsCount("<pkm.constPwd4PBE.ConstPassword4PBE2: void main(java.lang.String[])>", RequiredPredicateError.class, 3);
+		setErrorsCount("<pkm.constPwd4PBE.ConstPassword4PBE2: void main(java.lang.String[])>", RequiredPredicateError.class, 4);
 		setErrorsCount("<pkm.constPwd4PBE.ConstPassword4PBE2: void main(java.lang.String[])>", ConstraintError.class, 2);
 		setErrorsCount("<pkm.constPwd4PBE.ConstPassword4PBE2: void main(java.lang.String[])>", TypestateError.class, 1);
 		setErrorsCount("<pkm.constPwd4PBE.ConstPassword4PBE2: void main(java.lang.String[])>", ForbiddenMethodError.class, 1);
@@ -187,7 +187,7 @@ public class BragaCryptoMisusesTest extends AbstractHeadlessTest {
 		MavenProject mavenProject = createAndCompile(mavenProjectPath);
 		HeadlessCryptoScanner scanner = createScanner(mavenProject);
 
-		setErrorsCount("<wc.customCrypto.Manual3DES: void main(java.lang.String[])>", RequiredPredicateError.class, 3);
+		setErrorsCount("<wc.customCrypto.Manual3DES: void main(java.lang.String[])>", RequiredPredicateError.class, 4);
 		setErrorsCount("<wc.customCrypto.Manual3DES: void main(java.lang.String[])>", ConstraintError.class, 2);
 		setErrorsCount("<wc.customCrypto.Manual3DES: void main(java.lang.String[])>", TypestateError.class, 1);
 		
@@ -198,7 +198,7 @@ public class BragaCryptoMisusesTest extends AbstractHeadlessTest {
 		// negative test case
 		setErrorsCount("<wc.customCrypto.RawSignatureRSA: void negativeTestCase()>", ConstraintError.class, 2);
 		setErrorsCount("<wc.customCrypto.RawSignatureRSA: void negativeTestCase()>", TypestateError.class, 1);
-		setErrorsCount("<wc.customCrypto.RawSignatureRSA: void negativeTestCase()>", RequiredPredicateError.class, 2);
+		setErrorsCount("<wc.customCrypto.RawSignatureRSA: void negativeTestCase()>", RequiredPredicateError.class, 5);
 		
 		setErrorsCount("<wc.customCrypto.RawSignatureRSAwHash: void main(java.lang.String[])>", RequiredPredicateError.class, 0);
 		setErrorsCount("<wc.customCrypto.RawSignatureRSAwHash: void main(java.lang.String[])>", TypestateError.class, 1);
@@ -218,19 +218,19 @@ public class BragaCryptoMisusesTest extends AbstractHeadlessTest {
 		setErrorsCount("<pkc.enc.deterministicCrypto.DeterministicEncryptionRSA: void main(java.lang.String[])>", ForbiddenMethodError.class, 1);
 		setErrorsCount("<pkc.enc.deterministicCrypto.DeterministicEncryptionRSA: void main(java.lang.String[])>", ConstraintError.class, 1);
 		setErrorsCount("<pkc.enc.deterministicCrypto.DeterministicEncryptionRSA: void main(java.lang.String[])>", IncompleteOperationError.class, 4);
-		setErrorsCount("<pkc.enc.deterministicCrypto.DeterministicEncryptionRSA: void main(java.lang.String[])>", RequiredPredicateError.class, 2);
+		setErrorsCount("<pkc.enc.deterministicCrypto.DeterministicEncryptionRSA: void main(java.lang.String[])>", RequiredPredicateError.class, 5);
 		setErrorsCount("<pkc.enc.deterministicCrypto.DeterministicEncryptionRSA: void main(java.lang.String[])>", TypestateError.class, 0);
 		setErrorsCount("<pkc.enc.deterministicCrypto.DeterministicEncryptionRSA1: void main(java.lang.String[])>", ConstraintError.class, 3);
 		setErrorsCount("<pkc.enc.deterministicCrypto.DeterministicEncryptionRSA1: void main(java.lang.String[])>", IncompleteOperationError.class, 4);
-		setErrorsCount("<pkc.enc.deterministicCrypto.DeterministicEncryptionRSA1: void main(java.lang.String[])>", RequiredPredicateError.class, 2);
+		setErrorsCount("<pkc.enc.deterministicCrypto.DeterministicEncryptionRSA1: void main(java.lang.String[])>", RequiredPredicateError.class, 5);
 		setErrorsCount("<pkc.enc.deterministicCrypto.DeterministicEncryptionRSA1: void main(java.lang.String[])>", TypestateError.class, 0);
 		setErrorsCount("<pkc.enc.deterministicCrypto.DeterministicEncryptionRSA2: void main(java.lang.String[])>", ConstraintError.class, 1);
 		setErrorsCount("<pkc.enc.deterministicCrypto.DeterministicEncryptionRSA2: void main(java.lang.String[])>", IncompleteOperationError.class, 4);
-		setErrorsCount("<pkc.enc.deterministicCrypto.DeterministicEncryptionRSA2: void main(java.lang.String[])>", RequiredPredicateError.class, 2);
+		setErrorsCount("<pkc.enc.deterministicCrypto.DeterministicEncryptionRSA2: void main(java.lang.String[])>", RequiredPredicateError.class, 5);
 		setErrorsCount("<pkc.enc.deterministicCrypto.DeterministicEncryptionRSA2: void main(java.lang.String[])>", TypestateError.class, 0);
 		setErrorsCount("<pkc.enc.deterministicCrypto.DeterministicEncryptionRSA3: void main(java.lang.String[])>", ConstraintError.class, 1);
 		setErrorsCount("<pkc.enc.deterministicCrypto.DeterministicEncryptionRSA3: void main(java.lang.String[])>", IncompleteOperationError.class, 4);
-		setErrorsCount("<pkc.enc.deterministicCrypto.DeterministicEncryptionRSA3: void main(java.lang.String[])>", RequiredPredicateError.class, 2);
+		setErrorsCount("<pkc.enc.deterministicCrypto.DeterministicEncryptionRSA3: void main(java.lang.String[])>", RequiredPredicateError.class, 5);
 		setErrorsCount("<pkc.enc.deterministicCrypto.DeterministicEncryptionRSA3: void main(java.lang.String[])>", TypestateError.class, 0);
 
 		scanner.exec();
@@ -284,9 +284,12 @@ public class BragaCryptoMisusesTest extends AbstractHeadlessTest {
 		HeadlessCryptoScanner scanner = createScanner(mavenProject);
 
 		setErrorsCount("<pkm.ImproperKeyLen.ImproperKeySizeRSA1: void main(java.lang.String[])>", ConstraintError.class, 1);
+		setErrorsCount("<pkm.ImproperKeyLen.ImproperKeySizeRSA1: void main(java.lang.String[])>", RequiredPredicateError.class, 1);
 		setErrorsCount("<pkm.ImproperKeyLen.ImproperKeySizeRSA2: void main(java.lang.String[])>", ConstraintError.class, 1);
+		setErrorsCount("<pkm.ImproperKeyLen.ImproperKeySizeRSA2: void main(java.lang.String[])>", RequiredPredicateError.class, 1);
 		setErrorsCount("<pkm.ImproperKeyLen.ImproperKeySizeRSA3: void main(java.lang.String[])>", ConstraintError.class, 1);
 		setErrorsCount("<pkm.ImproperKeyLen.ImproperKeySizeRSA4: void main(java.lang.String[])>", ConstraintError.class, 1);
+		setErrorsCount("<pkm.ImproperKeyLen.ImproperKeySizeRSA4: void main(java.lang.String[])>", RequiredPredicateError.class, 1);
 		setErrorsCount("<pkm.ImproperKeyLen.ImproperKeySizeRSA5: void main(java.lang.String[])>", ConstraintError.class, 1);
 		setErrorsCount("<pkm.ImproperKeyLen.ImproperKeySizeRSA6: void main(java.lang.String[])>", ConstraintError.class, 1);
 
@@ -360,35 +363,35 @@ public class BragaCryptoMisusesTest extends AbstractHeadlessTest {
 		
 		// negative test case
 		setErrorsCount("<pkc.ecc.insecurecurves.InsecureCurve_secp112r1: void negativeTestCase()>", ConstraintError.class, 1);
-		setErrorsCount("<pkc.ecc.insecurecurves.InsecureCurve_secp112r1: void negativeTestCase()>", RequiredPredicateError.class, 1);
+		setErrorsCount("<pkc.ecc.insecurecurves.InsecureCurve_secp112r1: void negativeTestCase()>", RequiredPredicateError.class, 2);
 
 		// negative test case
 		setErrorsCount("<pkc.ecc.insecurecurves.InsecureCurve_secp128r1: void negativeTestCase()>", ConstraintError.class, 1);
-		setErrorsCount("<pkc.ecc.insecurecurves.InsecureCurve_secp128r1: void negativeTestCase()>", RequiredPredicateError.class, 1);
+		setErrorsCount("<pkc.ecc.insecurecurves.InsecureCurve_secp128r1: void negativeTestCase()>", RequiredPredicateError.class, 2);
 
 		// negative test case
 		setErrorsCount("<pkc.ecc.insecurecurves.InsecureCurve_secp160k1: void negativeTestCase()>", ConstraintError.class, 1);
-		setErrorsCount("<pkc.ecc.insecurecurves.InsecureCurve_secp160k1: void negativeTestCase()>", RequiredPredicateError.class, 1);
+		setErrorsCount("<pkc.ecc.insecurecurves.InsecureCurve_secp160k1: void negativeTestCase()>", RequiredPredicateError.class, 2);
 
 		// negative test case
 		setErrorsCount("<pkc.ecc.insecurecurves.InsecureCurve_secp160r1: void negativeTestCase()>", ConstraintError.class, 1);
-		setErrorsCount("<pkc.ecc.insecurecurves.InsecureCurve_secp160r1: void negativeTestCase()>", RequiredPredicateError.class, 1);
+		setErrorsCount("<pkc.ecc.insecurecurves.InsecureCurve_secp160r1: void negativeTestCase()>", RequiredPredicateError.class, 2);
 
 		// negative test case
 		setErrorsCount("<pkc.ecc.insecurecurves.InsecureCurve_sect113r1: void negativeTestCase()>", ConstraintError.class, 1);
-		setErrorsCount("<pkc.ecc.insecurecurves.InsecureCurve_sect113r1: void negativeTestCase()>", RequiredPredicateError.class, 1);
+		setErrorsCount("<pkc.ecc.insecurecurves.InsecureCurve_sect113r1: void negativeTestCase()>", RequiredPredicateError.class, 2);
 		
 		// negative test case
 		setErrorsCount("<pkc.ecc.insecurecurves.InsecureCurve_sect131r1: void negativeTestCase()>", ConstraintError.class, 1);
-		setErrorsCount("<pkc.ecc.insecurecurves.InsecureCurve_sect131r1: void negativeTestCase()>", RequiredPredicateError.class, 1);
+		setErrorsCount("<pkc.ecc.insecurecurves.InsecureCurve_sect131r1: void negativeTestCase()>", RequiredPredicateError.class, 2);
 
 		// negative test case
 		setErrorsCount("<pkc.ecc.insecurecurves.InsecureCurve_sect193r1: void negativeTestCase()>", ConstraintError.class, 1);
-		setErrorsCount("<pkc.ecc.insecurecurves.InsecureCurve_sect193r1: void negativeTestCase()>", RequiredPredicateError.class, 1);
+		setErrorsCount("<pkc.ecc.insecurecurves.InsecureCurve_sect193r1: void negativeTestCase()>", RequiredPredicateError.class, 2);
 		
 		// negative test case
 		setErrorsCount("<pkc.ecc.insecurecurves.InsecureCurveECDH1: void negativeTestCase()>", ConstraintError.class, 1);
-		setErrorsCount("<pkc.ecc.insecurecurves.InsecureCurveECDH1: void negativeTestCase()>", RequiredPredicateError.class, 1);
+		setErrorsCount("<pkc.ecc.insecurecurves.InsecureCurveECDH1: void negativeTestCase()>", RequiredPredicateError.class, 2);
 
 		scanner.exec();
 		assertErrors();
@@ -406,19 +409,19 @@ public class BragaCryptoMisusesTest extends AbstractHeadlessTest {
 		setErrorsCount("<pdf.insecureDefault.InsecureDefaultPBE: void main(java.lang.String[])>", ConstraintError.class, 1);
 		setErrorsCount("<pdf.insecureDefault.InsecureDefaultPBE: void main(java.lang.String[])>", ForbiddenMethodError.class, 1);
 		setErrorsCount("<pdf.insecureDefault.InsecureDefault3DES: void main(java.lang.String[])>", ConstraintError.class, 2);
-		setErrorsCount("<pdf.insecureDefault.InsecureDefault3DES: void main(java.lang.String[])>", RequiredPredicateError.class, 2);
+		setErrorsCount("<pdf.insecureDefault.InsecureDefault3DES: void main(java.lang.String[])>", RequiredPredicateError.class, 3);
 		setErrorsCount("<pdf.insecureDefault.InsecureDefault3DES: void main(java.lang.String[])>", TypestateError.class, 1);
 		setErrorsCount("<pdf.insecureDefault.InsecureDefaultAES: void main(java.lang.String[])>", TypestateError.class, 1);
 		setErrorsCount("<pdf.insecureDefault.InsecureDefaultAES: void main(java.lang.String[])>", ConstraintError.class, 1);
 		
 		// positive test case
 		setErrorsCount("<pdf.insecureDefault.InsecureDefaultOAEP: void positiveTestCase()>", ConstraintError.class, 1);
-		setErrorsCount("<pdf.insecureDefault.InsecureDefaultOAEP: void positiveTestCase()>", RequiredPredicateError.class, 4);
+		setErrorsCount("<pdf.insecureDefault.InsecureDefaultOAEP: void positiveTestCase()>", RequiredPredicateError.class, 7);
 		setErrorsCount("<pdf.insecureDefault.InsecureDefaultOAEP: void positiveTestCase()>", TypestateError.class, 1);
 		
 		// negative test case
 		setErrorsCount("<pdf.insecureDefault.InsecureDefaultOAEP: void negativeTestCase()>", ConstraintError.class, 2);
-		setErrorsCount("<pdf.insecureDefault.InsecureDefaultOAEP: void negativeTestCase()>", RequiredPredicateError.class, 4);
+		setErrorsCount("<pdf.insecureDefault.InsecureDefaultOAEP: void negativeTestCase()>", RequiredPredicateError.class, 7);
 		setErrorsCount("<pdf.insecureDefault.InsecureDefaultOAEP: void negativeTestCase()>", TypestateError.class, 1);
 		
 		// positive test case
@@ -429,7 +432,7 @@ public class BragaCryptoMisusesTest extends AbstractHeadlessTest {
 		
 		// negative test case
 		setErrorsCount("<pdf.insecureDefault.InsecureDefaultRSA: void negativeTestCase()>", IncompleteOperationError.class, 4);
-		setErrorsCount("<pdf.insecureDefault.InsecureDefaultRSA: void negativeTestCase()>", RequiredPredicateError.class, 2);
+		setErrorsCount("<pdf.insecureDefault.InsecureDefaultRSA: void negativeTestCase()>", RequiredPredicateError.class, 5);
 		setErrorsCount("<pdf.insecureDefault.InsecureDefaultRSA: void negativeTestCase()>", TypestateError.class, 0);
 		setErrorsCount("<pdf.insecureDefault.InsecureDefaultRSA: void negativeTestCase()>", ConstraintError.class, 1);
 
@@ -454,7 +457,7 @@ public class BragaCryptoMisusesTest extends AbstractHeadlessTest {
 		// negative test case
 		setErrorsCount("<pkc.enc.insecurePadding.InsecurePaddingRSA1: void negativeTestCase()>", TypestateError.class, 0);
 		setErrorsCount("<pkc.enc.insecurePadding.InsecurePaddingRSA1: void negativeTestCase()>", IncompleteOperationError.class, 4);
-		setErrorsCount("<pkc.enc.insecurePadding.InsecurePaddingRSA1: void negativeTestCase()>", RequiredPredicateError.class, 2);
+		setErrorsCount("<pkc.enc.insecurePadding.InsecurePaddingRSA1: void negativeTestCase()>", RequiredPredicateError.class, 5);
 		setErrorsCount("<pkc.enc.insecurePadding.InsecurePaddingRSA1: void negativeTestCase()>", ConstraintError.class, 3);
 		
 		// positive test case
@@ -466,7 +469,7 @@ public class BragaCryptoMisusesTest extends AbstractHeadlessTest {
 		// negative test case
 		setErrorsCount("<pkc.enc.insecurePadding.InsecurePaddingRSA2: void negativeTestCase()>", TypestateError.class, 0);
 		setErrorsCount("<pkc.enc.insecurePadding.InsecurePaddingRSA2: void negativeTestCase()>", IncompleteOperationError.class, 4);
-		setErrorsCount("<pkc.enc.insecurePadding.InsecurePaddingRSA2: void negativeTestCase()>", RequiredPredicateError.class, 2);
+		setErrorsCount("<pkc.enc.insecurePadding.InsecurePaddingRSA2: void negativeTestCase()>", RequiredPredicateError.class, 5);
 		setErrorsCount("<pkc.enc.insecurePadding.InsecurePaddingRSA2: void negativeTestCase()>", ConstraintError.class, 1);
 		
 		// positive test case
@@ -478,7 +481,7 @@ public class BragaCryptoMisusesTest extends AbstractHeadlessTest {
 		// negative test case
 		setErrorsCount("<pkc.enc.insecurePadding.InsecurePaddingRSA3: void negativeTestCase()>", TypestateError.class, 0);
 		setErrorsCount("<pkc.enc.insecurePadding.InsecurePaddingRSA3: void negativeTestCase()>", IncompleteOperationError.class, 4);
-		setErrorsCount("<pkc.enc.insecurePadding.InsecurePaddingRSA3: void negativeTestCase()>", RequiredPredicateError.class, 2);
+		setErrorsCount("<pkc.enc.insecurePadding.InsecurePaddingRSA3: void negativeTestCase()>", RequiredPredicateError.class, 5);
 		setErrorsCount("<pkc.enc.insecurePadding.InsecurePaddingRSA3: void negativeTestCase()>", ConstraintError.class, 1);
 
 		scanner.exec();
@@ -500,7 +503,7 @@ public class BragaCryptoMisusesTest extends AbstractHeadlessTest {
 		// negative test case
 		setErrorsCount("<pkc.sign.insecurePaddingSign.PKCS1Signature: void negativeTestCase()>", ConstraintError.class, 2);
 		setErrorsCount("<pkc.sign.insecurePaddingSign.PKCS1Signature: void negativeTestCase()>", TypestateError.class, 1);
-		setErrorsCount("<pkc.sign.insecurePaddingSign.PKCS1Signature: void negativeTestCase()>", RequiredPredicateError.class, 2);
+		setErrorsCount("<pkc.sign.insecurePaddingSign.PKCS1Signature: void negativeTestCase()>", RequiredPredicateError.class, 5);
 		
 		// positive test case
 		setErrorsCount("<pkc.sign.insecurePaddingSign.PKCS1Signature1: void positiveTestCase()>", TypestateError.class, 1);
@@ -508,7 +511,7 @@ public class BragaCryptoMisusesTest extends AbstractHeadlessTest {
 		// negative test case
 		setErrorsCount("<pkc.sign.insecurePaddingSign.PKCS1Signature1: void negativeTestCase()>", ConstraintError.class, 1);
 		setErrorsCount("<pkc.sign.insecurePaddingSign.PKCS1Signature1: void negativeTestCase()>", TypestateError.class, 1);
-		setErrorsCount("<pkc.sign.insecurePaddingSign.PKCS1Signature1: void negativeTestCase()>", RequiredPredicateError.class, 2);
+		setErrorsCount("<pkc.sign.insecurePaddingSign.PKCS1Signature1: void negativeTestCase()>", RequiredPredicateError.class, 5);
 
 		// positive test case
 		setErrorsCount("<pkc.sign.insecurePaddingSign.PKCS1Signature2: void positiveTestCase()>", TypestateError.class, 1);
@@ -516,7 +519,7 @@ public class BragaCryptoMisusesTest extends AbstractHeadlessTest {
 		// negative test case
 		setErrorsCount("<pkc.sign.insecurePaddingSign.PKCS1Signature2: void negativeTestCase()>", ConstraintError.class, 1);
 		setErrorsCount("<pkc.sign.insecurePaddingSign.PKCS1Signature2: void negativeTestCase()>", TypestateError.class, 1);
-		setErrorsCount("<pkc.sign.insecurePaddingSign.PKCS1Signature2: void negativeTestCase()>", RequiredPredicateError.class, 2);
+		setErrorsCount("<pkc.sign.insecurePaddingSign.PKCS1Signature2: void negativeTestCase()>", RequiredPredicateError.class, 5);
 		
 		// positive test case
 		setErrorsCount("<pkc.sign.insecurePaddingSign.PSSwSHA1Signature: void positiveTestCase()>", ConstraintError.class, 1);
@@ -525,7 +528,7 @@ public class BragaCryptoMisusesTest extends AbstractHeadlessTest {
 		// negative test case
 		setErrorsCount("<pkc.sign.insecurePaddingSign.PSSwSHA1Signature: void negativeTestCase()>", ConstraintError.class, 2);
 		setErrorsCount("<pkc.sign.insecurePaddingSign.PSSwSHA1Signature: void negativeTestCase()>", TypestateError.class, 1);
-		setErrorsCount("<pkc.sign.insecurePaddingSign.PSSwSHA1Signature: void negativeTestCase()>", RequiredPredicateError.class, 2);
+		setErrorsCount("<pkc.sign.insecurePaddingSign.PSSwSHA1Signature: void negativeTestCase()>", RequiredPredicateError.class, 5);
 		
 		// positive test case
 		setErrorsCount("<pkc.sign.insecurePaddingSign.PSSwSHA1Signature1: void positiveTestCase()>", ConstraintError.class, 1);
@@ -534,7 +537,7 @@ public class BragaCryptoMisusesTest extends AbstractHeadlessTest {
 		// negative test case
 		setErrorsCount("<pkc.sign.insecurePaddingSign.PSSwSHA1Signature1: void negativeTestCase()>", ConstraintError.class, 2);
 		setErrorsCount("<pkc.sign.insecurePaddingSign.PSSwSHA1Signature1: void negativeTestCase()>", TypestateError.class, 1);
-		setErrorsCount("<pkc.sign.insecurePaddingSign.PSSwSHA1Signature1: void negativeTestCase()>", RequiredPredicateError.class, 2);
+		setErrorsCount("<pkc.sign.insecurePaddingSign.PSSwSHA1Signature1: void negativeTestCase()>", RequiredPredicateError.class, 5);
 		
 		// positive test case
 		setErrorsCount("<pkc.sign.insecurePaddingSign.PSSwSHA1Signature2: void positiveTestCase()>", ConstraintError.class, 1);
@@ -543,7 +546,7 @@ public class BragaCryptoMisusesTest extends AbstractHeadlessTest {
 		// negative test case
 		setErrorsCount("<pkc.sign.insecurePaddingSign.PSSwSHA1Signature2: void negativeTestCase()>", ConstraintError.class, 2);
 		setErrorsCount("<pkc.sign.insecurePaddingSign.PSSwSHA1Signature2: void negativeTestCase()>", TypestateError.class, 1);
-		setErrorsCount("<pkc.sign.insecurePaddingSign.PSSwSHA1Signature2: void negativeTestCase()>", RequiredPredicateError.class, 2);
+		setErrorsCount("<pkc.sign.insecurePaddingSign.PSSwSHA1Signature2: void negativeTestCase()>", RequiredPredicateError.class, 5);
 
 		scanner.exec();
 		assertErrors();
@@ -581,25 +584,27 @@ public class BragaCryptoMisusesTest extends AbstractHeadlessTest {
 
 		// negative test case
 		setErrorsCount("<pkc.ka.issuesDHandECDH.NonAuthenticatedEphemeralDH_1024: void negativeTestCase()>", ConstraintError.class, 2);
-		setErrorsCount("<pkc.ka.issuesDHandECDH.NonAuthenticatedEphemeralDH_1024: void negativeTestCase()>", RequiredPredicateError.class, 8);
+		setErrorsCount("<pkc.ka.issuesDHandECDH.NonAuthenticatedEphemeralDH_1024: void negativeTestCase()>", RequiredPredicateError.class, 16);
 		
 		setErrorsCount("<pkc.ka.issuesDHandECDH.NonAuthenticatedEphemeralDH_512: void main(java.lang.String[])>", ConstraintError.class, 2);
-		setErrorsCount("<pkc.ka.issuesDHandECDH.NonAuthenticatedEphemeralDH_512: void main(java.lang.String[])>", RequiredPredicateError.class, 8);
+		setErrorsCount("<pkc.ka.issuesDHandECDH.NonAuthenticatedEphemeralDH_512: void main(java.lang.String[])>", RequiredPredicateError.class, 16);
 		setErrorsCount("<pkc.ka.issuesDHandECDH.NonAuthenticatedEphemeralECDH_112: void main(java.lang.String[])>", ConstraintError.class, 2);
-		setErrorsCount("<pkc.ka.issuesDHandECDH.NonAuthenticatedEphemeralECDH_112: void main(java.lang.String[])>", RequiredPredicateError.class, 8);
+		setErrorsCount("<pkc.ka.issuesDHandECDH.NonAuthenticatedEphemeralECDH_112: void main(java.lang.String[])>", RequiredPredicateError.class, 16);
 		setErrorsCount("<pkc.ka.issuesDHandECDH.NonAuthenticatedEphemeralECDH_80: void main(java.lang.String[])>", ConstraintError.class, 2);
-		setErrorsCount("<pkc.ka.issuesDHandECDH.NonAuthenticatedEphemeralECDH_80: void main(java.lang.String[])>", RequiredPredicateError.class, 8);
-		setErrorsCount("<pkc.ka.issuesDHandECDH.NonAuthenticatedDH_512: void main(java.lang.String[])>", RequiredPredicateError.class, 10);
+		setErrorsCount("<pkc.ka.issuesDHandECDH.NonAuthenticatedEphemeralECDH_80: void main(java.lang.String[])>", RequiredPredicateError.class, 16);
+		setErrorsCount("<pkc.ka.issuesDHandECDH.NonAuthenticatedDH_512: void main(java.lang.String[])>", RequiredPredicateError.class, 18);
 		setErrorsCount("<pkc.ka.issuesDHandECDH.NonAuthenticatedDH_512: void main(java.lang.String[])>", ConstraintError.class, 1);
+		setErrorsCount("<pkc.ka.issuesDHandECDH.NonAuthenticatedDH_512: void main(java.lang.String[])>", IncompleteOperationError.class, 1);
 		
 		// positive test case
 		setErrorsCount("<pkc.ka.issuesDHandECDH.NonAuthenticatedDH_1024: void positiveTestCase()>", ConstraintError.class, 0);
-		setErrorsCount("<pkc.ka.issuesDHandECDH.NonAuthenticatedDH_1024: void positiveTestCase()>", RequiredPredicateError.class, 10);
+		setErrorsCount("<pkc.ka.issuesDHandECDH.NonAuthenticatedDH_1024: void positiveTestCase()>", RequiredPredicateError.class, 18);
 		setErrorsCount("<pkc.ka.issuesDHandECDH.NonAuthenticatedDH_1024: void positiveTestCase()>", IncompleteOperationError.class, 1);
 		
 		// negative test case
 		setErrorsCount("<pkc.ka.issuesDHandECDH.NonAuthenticatedDH_1024: void negativeTestCase()>", ConstraintError.class, 1);
-		setErrorsCount("<pkc.ka.issuesDHandECDH.NonAuthenticatedDH_1024: void negativeTestCase()>", RequiredPredicateError.class, 10);
+		setErrorsCount("<pkc.ka.issuesDHandECDH.NonAuthenticatedDH_1024: void negativeTestCase()>", RequiredPredicateError.class, 18);
+		setErrorsCount("<pkc.ka.issuesDHandECDH.NonAuthenticatedDH_1024: void negativeTestCase()>", IncompleteOperationError.class, 1);
 
 		scanner.exec();
 		assertErrors();
@@ -663,15 +668,15 @@ public class BragaCryptoMisusesTest extends AbstractHeadlessTest {
 		MavenProject mavenProject = createAndCompile(mavenProjectPath);
 		HeadlessCryptoScanner scanner = createScanner(mavenProject);
 
-		setErrorsCount("<cib.paramsPBE.PBEwConstSalt1: void main(java.lang.String[])>", RequiredPredicateError.class, 3);
+		setErrorsCount("<cib.paramsPBE.PBEwConstSalt1: void main(java.lang.String[])>", RequiredPredicateError.class, 4);
 		setErrorsCount("<cib.paramsPBE.PBEwConstSalt1: void main(java.lang.String[])>", ConstraintError.class, 1);
 		setErrorsCount("<cib.paramsPBE.PBEwConstSalt1: void main(java.lang.String[])>", ForbiddenMethodError.class, 1);
 		setErrorsCount("<cib.paramsPBE.PBEwConstSalt1: void main(java.lang.String[])>", TypestateError.class, 1);
-		setErrorsCount("<cib.paramsPBE.PBEwSmallCount1: void main(java.lang.String[])>", RequiredPredicateError.class, 3);
+		setErrorsCount("<cib.paramsPBE.PBEwSmallCount1: void main(java.lang.String[])>", RequiredPredicateError.class, 4);
 		setErrorsCount("<cib.paramsPBE.PBEwSmallCount1: void main(java.lang.String[])>", ConstraintError.class, 1);
 		setErrorsCount("<cib.paramsPBE.PBEwSmallCount1: void main(java.lang.String[])>", ForbiddenMethodError.class, 1);
 		setErrorsCount("<cib.paramsPBE.PBEwSmallCount1: void main(java.lang.String[])>", TypestateError.class, 1);
-		setErrorsCount("<cib.paramsPBE.PBEwSmallSalt: void main(java.lang.String[])>", RequiredPredicateError.class, 3);
+		setErrorsCount("<cib.paramsPBE.PBEwSmallSalt: void main(java.lang.String[])>", RequiredPredicateError.class, 4);
 		setErrorsCount("<cib.paramsPBE.PBEwSmallSalt: void main(java.lang.String[])>", ConstraintError.class, 1);
 		setErrorsCount("<cib.paramsPBE.PBEwSmallSalt: void main(java.lang.String[])>", ForbiddenMethodError.class, 1);
 		setErrorsCount("<cib.paramsPBE.PBEwSmallSalt: void main(java.lang.String[])>", TypestateError.class, 1);
@@ -707,11 +712,11 @@ public class BragaCryptoMisusesTest extends AbstractHeadlessTest {
 		HeadlessCryptoScanner scanner = createScanner(mavenProject);
 
 		setErrorsCount("<cib.printPrivSecKey.PrintECDHPrivKey1: void main(java.lang.String[])>", ConstraintError.class, 2);
-		setErrorsCount("<cib.printPrivSecKey.PrintECDHPrivKey1: void main(java.lang.String[])>", RequiredPredicateError.class, 8);
+		setErrorsCount("<cib.printPrivSecKey.PrintECDHPrivKey1: void main(java.lang.String[])>", RequiredPredicateError.class, 16);
 		setErrorsCount("<cib.printPrivSecKey.PrintECDHSecret1: void main(java.lang.String[])>", ConstraintError.class, 2);
-		setErrorsCount("<cib.printPrivSecKey.PrintECDHSecret1: void main(java.lang.String[])>", RequiredPredicateError.class, 8);
+		setErrorsCount("<cib.printPrivSecKey.PrintECDHSecret1: void main(java.lang.String[])>", RequiredPredicateError.class, 16);
 		setErrorsCount("<cib.printPrivSecKey.PrintECDSAPrivKey1: void main(java.lang.String[])>", ConstraintError.class, 3);
-		setErrorsCount("<cib.printPrivSecKey.PrintECDSAPrivKey1: void main(java.lang.String[])>", RequiredPredicateError.class, 2);
+		setErrorsCount("<cib.printPrivSecKey.PrintECDSAPrivKey1: void main(java.lang.String[])>", RequiredPredicateError.class, 5);
 		
 		// positive test case
 		setErrorsCount("<cib.printPrivSecKey.PrintPrivKey1: void positiveTestCase()>", TypestateError.class, 1);
@@ -721,7 +726,7 @@ public class BragaCryptoMisusesTest extends AbstractHeadlessTest {
 		// negative test case
 		setErrorsCount("<cib.printPrivSecKey.PrintPrivKey1: void negativeTestCase()>", TypestateError.class, 1);
 		setErrorsCount("<cib.printPrivSecKey.PrintPrivKey1: void negativeTestCase()>", ConstraintError.class, 1);
-		setErrorsCount("<cib.printPrivSecKey.PrintPrivKey1: void negativeTestCase()>", RequiredPredicateError.class, 2);
+		setErrorsCount("<cib.printPrivSecKey.PrintPrivKey1: void negativeTestCase()>", RequiredPredicateError.class, 5);
 		
 		setErrorsCount("<cib.printPrivSecKey.PrintSecKey1: void main(java.lang.String[])>", TypestateError.class, 1);
 		
@@ -731,7 +736,7 @@ public class BragaCryptoMisusesTest extends AbstractHeadlessTest {
 		
 		// negative test case
 		setErrorsCount("<cib.printPrivSecKey.PrintDHSecret1: void negativeTestCase()>", ConstraintError.class, 2);
-		setErrorsCount("<cib.printPrivSecKey.PrintDHSecret1: void negativeTestCase()>", RequiredPredicateError.class, 8);
+		setErrorsCount("<cib.printPrivSecKey.PrintDHSecret1: void negativeTestCase()>", RequiredPredicateError.class, 16);
 
 		// positive test case
 		setErrorsCount("<cib.printPrivSecKey.PrintDHPrivKey1: void positiveTestCase()>", ConstraintError.class, 0);
@@ -739,7 +744,7 @@ public class BragaCryptoMisusesTest extends AbstractHeadlessTest {
 		
 		// negative test case
 		setErrorsCount("<cib.printPrivSecKey.PrintDHPrivKey1: void negativeTestCase()>", ConstraintError.class, 2);
-		setErrorsCount("<cib.printPrivSecKey.PrintDHPrivKey1: void negativeTestCase()>", RequiredPredicateError.class, 8);
+		setErrorsCount("<cib.printPrivSecKey.PrintDHPrivKey1: void negativeTestCase()>", RequiredPredicateError.class, 16);
 
 		scanner.exec();
 		assertErrors();
@@ -758,19 +763,19 @@ public class BragaCryptoMisusesTest extends AbstractHeadlessTest {
 		setErrorsCount("<wc.riskyInsecureCrypto.InsecureCryptoPBE: void main(java.lang.String[])>", ForbiddenMethodError.class, 1);
 		setErrorsCount("<wc.riskyInsecureCrypto.InsecureCrypto3DES: void main(java.lang.String[])>", TypestateError.class, 1);
 		setErrorsCount("<wc.riskyInsecureCrypto.InsecureCrypto3DES: void main(java.lang.String[])>", ConstraintError.class, 2);
-		setErrorsCount("<wc.riskyInsecureCrypto.InsecureCrypto3DES: void main(java.lang.String[])>", RequiredPredicateError.class, 2);
+		setErrorsCount("<wc.riskyInsecureCrypto.InsecureCrypto3DES: void main(java.lang.String[])>", RequiredPredicateError.class, 3);
 		setErrorsCount("<wc.riskyInsecureCrypto.InsecureCryptoBlowfish: void main(java.lang.String[])>", TypestateError.class, 1);
-		setErrorsCount("<wc.riskyInsecureCrypto.InsecureCryptoBlowfish: void main(java.lang.String[])>", RequiredPredicateError.class, 2);
+		setErrorsCount("<wc.riskyInsecureCrypto.InsecureCryptoBlowfish: void main(java.lang.String[])>", RequiredPredicateError.class, 3);
 		setErrorsCount("<wc.riskyInsecureCrypto.InsecureCryptoBlowfish: void main(java.lang.String[])>", ConstraintError.class, 2);
 		setErrorsCount("<wc.riskyInsecureCrypto.InsecureCryptoDES: void main(java.lang.String[])>", TypestateError.class, 1);
 		setErrorsCount("<wc.riskyInsecureCrypto.InsecureCryptoDES: void main(java.lang.String[])>", ConstraintError.class, 2);
-		setErrorsCount("<wc.riskyInsecureCrypto.InsecureCryptoDES: void main(java.lang.String[])>", RequiredPredicateError.class, 2);
+		setErrorsCount("<wc.riskyInsecureCrypto.InsecureCryptoDES: void main(java.lang.String[])>", RequiredPredicateError.class, 3);
 		setErrorsCount("<wc.riskyInsecureCrypto.InsecureCryptoDES_StreamCipher: void main(java.lang.String[])>", TypestateError.class, 5);
 		setErrorsCount("<wc.riskyInsecureCrypto.InsecureCryptoDES_StreamCipher: void main(java.lang.String[])>", ConstraintError.class, 5);
-		setErrorsCount("<wc.riskyInsecureCrypto.InsecureCryptoDES_StreamCipher: void main(java.lang.String[])>", RequiredPredicateError.class, 8);
+		setErrorsCount("<wc.riskyInsecureCrypto.InsecureCryptoDES_StreamCipher: void main(java.lang.String[])>", RequiredPredicateError.class, 9);
 		setErrorsCount("<wc.riskyInsecureCrypto.InsecureCryptoRC4_StreamCipher: void main(java.lang.String[])>", TypestateError.class, 1);
 		setErrorsCount("<wc.riskyInsecureCrypto.InsecureCryptoRC4_StreamCipher: void main(java.lang.String[])>", ConstraintError.class, 2);
-		setErrorsCount("<wc.riskyInsecureCrypto.InsecureCryptoRC4_StreamCipher: void main(java.lang.String[])>", RequiredPredicateError.class, 2);
+		setErrorsCount("<wc.riskyInsecureCrypto.InsecureCryptoRC4_StreamCipher: void main(java.lang.String[])>", RequiredPredicateError.class, 3);
 
 		scanner.exec();
 		assertErrors();
@@ -839,10 +844,10 @@ public class BragaCryptoMisusesTest extends AbstractHeadlessTest {
 		setErrorsCount("<cai.undefinedCSP.UndefinedProvider6: void main(java.lang.String[])>", ConstraintError.class, 1);
 		setErrorsCount("<cai.undefinedCSP.UndefinedProvider6: void main(java.lang.String[])>", TypestateError.class, 1);
 		setErrorsCount("<cai.undefinedCSP.UndefinedProvider7: void main(java.lang.String[])>", TypestateError.class, 1);
-		setErrorsCount("<cai.undefinedCSP.UndefinedProvider7: void main(java.lang.String[])>", RequiredPredicateError.class, 4);
+		setErrorsCount("<cai.undefinedCSP.UndefinedProvider7: void main(java.lang.String[])>", RequiredPredicateError.class, 7);
 		setErrorsCount("<cai.undefinedCSP.UndefinedProvider7: void main(java.lang.String[])>", ConstraintError.class, 2);
 		setErrorsCount("<cai.undefinedCSP.UndefinedProvider8: void main(java.lang.String[])>", ConstraintError.class, 1);
-		setErrorsCount("<cai.undefinedCSP.UndefinedProvider8: void main(java.lang.String[])>", RequiredPredicateError.class, 2);
+		setErrorsCount("<cai.undefinedCSP.UndefinedProvider8: void main(java.lang.String[])>", RequiredPredicateError.class, 5);
 		setErrorsCount("<cai.undefinedCSP.UndefinedProvider8: void main(java.lang.String[])>", IncompleteOperationError.class, 4);
 
 		scanner.exec();
@@ -860,82 +865,82 @@ public class BragaCryptoMisusesTest extends AbstractHeadlessTest {
 		// positive test case
 		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_384x160_1: void positiveTestCase()>", TypestateError.class, 1);
 		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_384x160_1: void positiveTestCase()>", ConstraintError.class, 1);
-		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_384x160_1: void positiveTestCase()>", RequiredPredicateError.class, 2);
+		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_384x160_1: void positiveTestCase()>", RequiredPredicateError.class, 5);
 		
 		// negative test case
 		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_384x160_1: void negativeTestCase()>", TypestateError.class, 1);
 		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_384x160_1: void negativeTestCase()>", ConstraintError.class, 2);
-		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_384x160_1: void negativeTestCase()>", RequiredPredicateError.class, 4);
+		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_384x160_1: void negativeTestCase()>", RequiredPredicateError.class, 7);
 
 		// positive test case
 		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_512x160_1: void positiveTestCase()>", TypestateError.class, 1);
 		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_512x160_1: void positiveTestCase()>", ConstraintError.class, 1);
-		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_512x160_1: void positiveTestCase()>", RequiredPredicateError.class, 2);
+		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_512x160_1: void positiveTestCase()>", RequiredPredicateError.class, 5);
 
 		// negative test case
 		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_512x160_1: void negativeTestCase()>", TypestateError.class, 1);
 		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_512x160_1: void negativeTestCase()>", ConstraintError.class, 2);
-		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_512x160_1: void negativeTestCase()>", RequiredPredicateError.class, 4);
+		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_512x160_1: void negativeTestCase()>", RequiredPredicateError.class, 7);
 		
 		// positive test case
 		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_768x160_1: void positiveTestCase()>", TypestateError.class, 1);
 		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_768x160_1: void positiveTestCase()>", ConstraintError.class, 1);
-		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_768x160_1: void positiveTestCase()>", RequiredPredicateError.class, 2);
+		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_768x160_1: void positiveTestCase()>", RequiredPredicateError.class, 5);
 
 		// negative test case
 		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_768x160_1: void negativeTestCase()>", TypestateError.class, 1);
 		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_768x160_1: void negativeTestCase()>", ConstraintError.class, 2);
-		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_768x160_1: void negativeTestCase()>", RequiredPredicateError.class, 4);
+		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_768x160_1: void negativeTestCase()>", RequiredPredicateError.class, 7);
 
 		// positive test case
 		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_768x256_1: void positiveTestCase()>", TypestateError.class, 1);
 		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_768x256_1: void positiveTestCase()>", ConstraintError.class, 1);
-		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_768x256_1: void positiveTestCase()>", RequiredPredicateError.class, 2);
+		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_768x256_1: void positiveTestCase()>", RequiredPredicateError.class, 5);
 
 		// negative test case
 		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_768x256_1: void negativeTestCase()>", TypestateError.class, 1);
 		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_768x256_1: void negativeTestCase()>", ConstraintError.class, 1);
-		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_768x256_1: void negativeTestCase()>", RequiredPredicateError.class, 4);
+		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_768x256_1: void negativeTestCase()>", RequiredPredicateError.class, 7);
 		
 		// positive test case
 		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_1024x160_1: void positiveTestCase()>", TypestateError.class, 1);
 		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_1024x160_1: void positiveTestCase()>", ConstraintError.class, 1);
-		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_1024x160_1: void positiveTestCase()>", RequiredPredicateError.class, 2);
+		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_1024x160_1: void positiveTestCase()>", RequiredPredicateError.class, 5);
 		
 		// negative test case
 		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_1024x160_1: void negativeTestCase()>", TypestateError.class, 1);
 		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_1024x160_1: void negativeTestCase()>", ConstraintError.class, 2);
-		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_1024x160_1: void negativeTestCase()>", RequiredPredicateError.class, 4);
+		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_1024x160_1: void negativeTestCase()>", RequiredPredicateError.class, 7);
 		
 		// positive test case
 		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_1024x256_1: void positiveTestCase()>", TypestateError.class, 1);
 		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_1024x256_1: void positiveTestCase()>", ConstraintError.class, 1);
-		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_1024x256_1: void positiveTestCase()>", RequiredPredicateError.class, 2);
+		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_1024x256_1: void positiveTestCase()>", RequiredPredicateError.class, 5);
 		
 		// negative test case
 		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_1024x256_1: void negativeTestCase()>", TypestateError.class, 1);
 		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_1024x256_1: void negativeTestCase()>", ConstraintError.class, 1);
-		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_1024x256_1: void negativeTestCase()>", RequiredPredicateError.class, 4);
+		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_1024x256_1: void negativeTestCase()>", RequiredPredicateError.class, 7);
 		
 		// positive test case
 		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_1024x384_1: void positiveTestCase()>", TypestateError.class, 1);
 		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_1024x384_1: void positiveTestCase()>", ConstraintError.class, 1);
-		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_1024x384_1: void positiveTestCase()>", RequiredPredicateError.class, 2);
+		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_1024x384_1: void positiveTestCase()>", RequiredPredicateError.class, 5);
 
 		// negative test case
 		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_1024x384_1: void negativeTestCase()>", TypestateError.class, 1);
 		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_1024x384_1: void negativeTestCase()>", ConstraintError.class, 1);
-		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_1024x384_1: void negativeTestCase()>", RequiredPredicateError.class, 4);
+		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_1024x384_1: void negativeTestCase()>", RequiredPredicateError.class, 7);
 		
 		// positive test case
 		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_2048x160_1: void positiveTestCase()>", TypestateError.class, 1);
 		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_2048x160_1: void positiveTestCase()>", ConstraintError.class, 1);
-		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_2048x160_1: void positiveTestCase()>", RequiredPredicateError.class, 2);
+		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_2048x160_1: void positiveTestCase()>", RequiredPredicateError.class, 5);
 
 		// negative test case
 		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_2048x160_1: void negativeTestCase()>", TypestateError.class, 1);
 		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_2048x160_1: void negativeTestCase()>", ConstraintError.class, 2);
-		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_2048x160_1: void negativeTestCase()>", RequiredPredicateError.class, 4);
+		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_2048x160_1: void negativeTestCase()>", RequiredPredicateError.class, 7);
 		
 		// positive test case
 		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_3072x160_1: void positiveTestCase()>", TypestateError.class, 1);
@@ -973,11 +978,11 @@ public class BragaCryptoMisusesTest extends AbstractHeadlessTest {
 		setErrorsCount("<pkc.sign.weakSignatureECDSA.RepeatedMessageNonceECDSA_2: void main(java.lang.String[])>", RequiredPredicateError.class, 2);
 		setErrorsCount("<pkc.sign.weakSignatureECDSA.RepeatedMessageNonceECDSA_3: void main(java.lang.String[])>", RequiredPredicateError.class, 2);
 		setErrorsCount("<pkc.sign.weakSignatureECDSA.RepeatedMessageNonceECDSA_4: void main(java.lang.String[])>", RequiredPredicateError.class, 2);
-		setErrorsCount("<pkc.sign.weakSignatureECDSA.SUN_80bits_ECDSA112wNONE1: void main(java.lang.String[])>", RequiredPredicateError.class, 2);
+		setErrorsCount("<pkc.sign.weakSignatureECDSA.SUN_80bits_ECDSA112wNONE1: void main(java.lang.String[])>", RequiredPredicateError.class, 5);
 		setErrorsCount("<pkc.sign.weakSignatureECDSA.SUN_80bits_ECDSA112wNONE1: void main(java.lang.String[])>", ConstraintError.class, 5);
-		setErrorsCount("<pkc.sign.weakSignatureECDSA.SUN_80bits_ECDSA112wNONE2: void main(java.lang.String[])>", RequiredPredicateError.class, 2);
+		setErrorsCount("<pkc.sign.weakSignatureECDSA.SUN_80bits_ECDSA112wNONE2: void main(java.lang.String[])>", RequiredPredicateError.class, 5);
 		setErrorsCount("<pkc.sign.weakSignatureECDSA.SUN_80bits_ECDSA112wNONE2: void main(java.lang.String[])>", ConstraintError.class, 3);
-		setErrorsCount("<pkc.sign.weakSignatureECDSA.SUN_80bits_ECDSA112wSHA1: void main(java.lang.String[])>", RequiredPredicateError.class, 2);
+		setErrorsCount("<pkc.sign.weakSignatureECDSA.SUN_80bits_ECDSA112wSHA1: void main(java.lang.String[])>", RequiredPredicateError.class, 5);
 		setErrorsCount("<pkc.sign.weakSignatureECDSA.SUN_80bits_ECDSA112wSHA1: void main(java.lang.String[])>", ConstraintError.class, 3);
 
 		scanner.exec();
@@ -992,13 +997,13 @@ public class BragaCryptoMisusesTest extends AbstractHeadlessTest {
 		MavenProject mavenProject = createAndCompile(mavenProjectPath);
 		HeadlessCryptoScanner scanner = createScanner(mavenProject);
 
-		setErrorsCount("<pkc.sign.weakSignatureRSA.PKCS1Sign1024xSHA1_1: void main(java.lang.String[])>", RequiredPredicateError.class, 2);
+		setErrorsCount("<pkc.sign.weakSignatureRSA.PKCS1Sign1024xSHA1_1: void main(java.lang.String[])>", RequiredPredicateError.class, 5);
 		setErrorsCount("<pkc.sign.weakSignatureRSA.PKCS1Sign1024xSHA1_1: void main(java.lang.String[])>", ConstraintError.class, 2);
 		setErrorsCount("<pkc.sign.weakSignatureRSA.PKCS1Sign1024xSHA1_1: void main(java.lang.String[])>", TypestateError.class, 1);
-		setErrorsCount("<pkc.sign.weakSignatureRSA.PKCS1Sign1024xSHA256_2: void main(java.lang.String[])>", RequiredPredicateError.class, 2);
+		setErrorsCount("<pkc.sign.weakSignatureRSA.PKCS1Sign1024xSHA256_2: void main(java.lang.String[])>", RequiredPredicateError.class, 5);
 		setErrorsCount("<pkc.sign.weakSignatureRSA.PKCS1Sign1024xSHA256_2: void main(java.lang.String[])>", ConstraintError.class, 1);
 		setErrorsCount("<pkc.sign.weakSignatureRSA.PKCS1Sign1024xSHA256_2: void main(java.lang.String[])>", TypestateError.class, 1);
-		setErrorsCount("<pkc.sign.weakSignatureRSA.PSSw1024xSHA1_1: void main(java.lang.String[])>", RequiredPredicateError.class, 2);
+		setErrorsCount("<pkc.sign.weakSignatureRSA.PSSw1024xSHA1_1: void main(java.lang.String[])>", RequiredPredicateError.class, 5);
 		setErrorsCount("<pkc.sign.weakSignatureRSA.PSSw1024xSHA1_1: void main(java.lang.String[])>", ConstraintError.class, 2);
 		setErrorsCount("<pkc.sign.weakSignatureRSA.PSSw1024xSHA1_1: void main(java.lang.String[])>", TypestateError.class, 1);
 		
@@ -1009,7 +1014,7 @@ public class BragaCryptoMisusesTest extends AbstractHeadlessTest {
 		// negative test case
 		setErrorsCount("<pkc.sign.weakSignatureRSA.PSSw1024xSHA256_2: void negativeTestCase()>", ConstraintError.class, 2);
 		setErrorsCount("<pkc.sign.weakSignatureRSA.PSSw1024xSHA256_2: void negativeTestCase()>", TypestateError.class, 1);
-		setErrorsCount("<pkc.sign.weakSignatureRSA.PSSw1024xSHA256_2: void negativeTestCase()>", RequiredPredicateError.class, 2);
+		setErrorsCount("<pkc.sign.weakSignatureRSA.PSSw1024xSHA256_2: void negativeTestCase()>", RequiredPredicateError.class, 5);
 
 		scanner.exec();
 		assertErrors();

--- a/CryptoAnalysis/src/test/java/tests/headless/CogniCryptGeneratedCodeTest.java
+++ b/CryptoAnalysis/src/test/java/tests/headless/CogniCryptGeneratedCodeTest.java
@@ -15,7 +15,7 @@ public class CogniCryptGeneratedCodeTest extends AbstractHeadlessTest {
 		HeadlessCryptoScanner scanner = createScanner(mavenProject);
 		
 		//All the following errors are false positives
-		setErrorsCount("<Crypto.KeyDeriv: javax.crypto.SecretKey getKey(char[])>", RequiredPredicateError.class, 2);
+		setErrorsCount("<Crypto.KeyDeriv: javax.crypto.SecretKey getKey(char[])>", RequiredPredicateError.class, 3);
 		setErrorsCount("<Crypto.KeyDeriv: javax.crypto.SecretKey getKey(char[])>", HardCodedError.class, 1);
 		setErrorsCount("<Crypto.Enc: byte[] encrypt(byte[],javax.crypto.SecretKey)>", RequiredPredicateError.class, 1);
 		setErrorsCount("<Crypto.Enc: byte[] decrypt(byte[],javax.crypto.SecretKey)>", RequiredPredicateError.class, 2);
@@ -32,9 +32,9 @@ public class CogniCryptGeneratedCodeTest extends AbstractHeadlessTest {
 		HeadlessCryptoScanner scanner = createScanner(mavenProject);
 
 		//All the following errors are false positives
-		setErrorsCount("<Crypto.PWHasher: java.lang.Boolean verifyPWHash(char[],java.lang.String)>", RequiredPredicateError.class, 2);
+		setErrorsCount("<Crypto.PWHasher: java.lang.Boolean verifyPWHash(char[],java.lang.String)>", RequiredPredicateError.class, 3);
 		setErrorsCount("<Crypto.PWHasher: java.lang.Boolean verifyPWHash(char[],java.lang.String)>", HardCodedError.class, 1);
-		setErrorsCount("<Crypto.PWHasher: java.lang.String createPWHash(char[])>", RequiredPredicateError.class, 1);
+		setErrorsCount("<Crypto.PWHasher: java.lang.String createPWHash(char[])>", RequiredPredicateError.class, 2);
 		setErrorsCount("<Crypto.PWHasher: java.lang.String createPWHash(char[])>", HardCodedError.class, 1);
 
 		scanner.exec();

--- a/CryptoAnalysis/src/test/java/tests/headless/CryptoGuardTest.java
+++ b/CryptoAnalysis/src/test/java/tests/headless/CryptoGuardTest.java
@@ -41,13 +41,13 @@ public class CryptoGuardTest extends AbstractHeadlessTest {
 		// This test case corresponds to the following project in CryptoGuard:
 		// https://github.com/CryptoGuardOSS/cryptoapi-bench/blob/master/src/main/java/org/cryptoapi/bench/brokencrypto/BrokenCryptoABICase2.java
 		setErrorsCount("<example.brokencrypto.BrokenCryptoABICase2: void doCrypto(java.lang.String)>", ConstraintError.class, 2);
-		setErrorsCount("<example.brokencrypto.BrokenCryptoABICase2: void doCrypto(java.lang.String)>", RequiredPredicateError.class, 1);
+		setErrorsCount("<example.brokencrypto.BrokenCryptoABICase2: void doCrypto(java.lang.String)>", RequiredPredicateError.class, 2);
 		setErrorsCount("<example.brokencrypto.BrokenCryptoABICase2: void doCrypto(java.lang.String)>", IncompleteOperationError.class, 1);
 		// ABICase3, ABICase4, ABICase9 not included as tests due to being similar to ABICase1 and ABICase2 above
 		
 		// This test case corresponds to the following project in CryptoGuard:
 		// https://github.com/CryptoGuardOSS/cryptoapi-bench/blob/master/src/main/java/org/cryptoapi/bench/brokencrypto/BrokenCryptoABICase5.java
-		setErrorsCount("<example.brokencrypto.BrokenCryptoABICase5: void doCrypto()>", RequiredPredicateError.class, 1);
+		setErrorsCount("<example.brokencrypto.BrokenCryptoABICase5: void doCrypto()>", RequiredPredicateError.class, 2);
 		setErrorsCount("<example.brokencrypto.BrokenCryptoABICase5: void doCrypto()>", IncompleteOperationError.class, 1);
 		setErrorsCount(ConstraintError.class, new TruePositives(1), new FalseNegatives(1, "ConstraintError not caught! //Related to https://github.com/CROSSINGTUD/CryptoAnalysis/issues/163"), "<example.brokencrypto.BrokenCryptoABICase5: void doCrypto()>");
 		// ABICase6, -7, -8, -10 not included as tests due to being similar to ABICase5 above
@@ -55,7 +55,7 @@ public class CryptoGuardTest extends AbstractHeadlessTest {
 		// This test case corresponds to the following project in CryptoGuard:
 		// https://github.com/CryptoGuardOSS/cryptoapi-bench/blob/master/src/main/java/org/cryptoapi/bench/brokencrypto/BrokenCryptoBBCase3.java
 		setErrorsCount("<example.brokencrypto.BrokenCryptoBBCase3: void go()>", ConstraintError.class, 2);
-		setErrorsCount("<example.brokencrypto.BrokenCryptoBBCase3: void go()>", RequiredPredicateError.class, 1);
+		setErrorsCount("<example.brokencrypto.BrokenCryptoBBCase3: void go()>", RequiredPredicateError.class, 2);
 		setErrorsCount("<example.brokencrypto.BrokenCryptoBBCase3: void go()>", IncompleteOperationError.class, 1);
 		// BBCase1, BBCase2, BBCase4, BBCase5 not included as tests due to being similar to BBCase3 above
 		
@@ -130,15 +130,17 @@ public class CryptoGuardTest extends AbstractHeadlessTest {
 		
 		// This test case corresponds to the following project in CryptoGuard:
 		// https://github.com/CryptoGuardOSS/cryptoapi-bench/blob/master/src/main/java/org/cryptoapi/bench/insecureasymmetriccrypto/InsecureAsymmetricCipherABICase1.java
-		setErrorsCount("<example.insecureasymmetriccrypto.InsecureAsymmetricCipherABICase1: void go(java.security.KeyPairGenerator,java.security.KeyPair)>", IncompleteOperationError.class, 2);
 		setErrorsCount("<example.insecureasymmetriccrypto.InsecureAsymmetricCipherABICase1: void main(java.lang.String[])>", TypestateError.class, 1);
-		setErrorsCount("<example.insecureasymmetriccrypto.InsecureAsymmetricCipherABICase1: void go(java.security.KeyPairGenerator,java.security.KeyPair)>", RequiredPredicateError.class, 2);
+		setErrorsCount("<example.insecureasymmetriccrypto.InsecureAsymmetricCipherABICase1: void main(java.lang.String[])>", RequiredPredicateError.class, 1);
+		setErrorsCount("<example.insecureasymmetriccrypto.InsecureAsymmetricCipherABICase1: void go(java.security.KeyPairGenerator,java.security.KeyPair)>", IncompleteOperationError.class, 2);
+		setErrorsCount("<example.insecureasymmetriccrypto.InsecureAsymmetricCipherABICase1: void go(java.security.KeyPairGenerator,java.security.KeyPair)>", RequiredPredicateError.class, 4);
 
 		// This test case corresponds to the following project in CryptoGuard:
 		// https://github.com/CryptoGuardOSS/cryptoapi-bench/blob/master/src/main/java/org/cryptoapi/bench/insecureasymmetriccrypto/InsecureAsymmetricCipherABICase2.java
 		setErrorsCount("<example.insecureasymmetriccrypto.InsecureAsymmetricCipherABICase2: void go(java.security.KeyPairGenerator,java.security.KeyPair)>", IncompleteOperationError.class, 2);
-		setErrorsCount("<example.insecureasymmetriccrypto.InsecureAsymmetricCipherABICase2: void go(java.security.KeyPairGenerator,java.security.KeyPair)>", RequiredPredicateError.class, 2);
+		setErrorsCount("<example.insecureasymmetriccrypto.InsecureAsymmetricCipherABICase2: void go(java.security.KeyPairGenerator,java.security.KeyPair)>", RequiredPredicateError.class, 4);
 		setErrorsCount("<example.insecureasymmetriccrypto.InsecureAsymmetricCipherABICase2: void main(java.lang.String[])>", ConstraintError.class, 1);
+		setErrorsCount("<example.insecureasymmetriccrypto.InsecureAsymmetricCipherABICase2: void main(java.lang.String[])>", RequiredPredicateError.class, 1);
 		// In the case above, misuse is caught correctly, but the keysize is reported to be 0
 		// and not 1024, as it really is. This is caused because of the structure of the project
 		// as explained in the issue: https://github.com/CROSSINGTUD/CryptoAnalysis/issues/163
@@ -147,7 +149,7 @@ public class CryptoGuardTest extends AbstractHeadlessTest {
 		// https://github.com/CryptoGuardOSS/cryptoapi-bench/blob/master/src/main/java/org/cryptoapi/bench/insecureasymmetriccrypto/InsecureAsymmetricCipherBB Case1.java
 		setErrorsCount("<example.insecureasymmetriccrypto.InsecureAsymmetricCipherBBCase1: void go()>", IncompleteOperationError.class, 2);
 		setErrorsCount("<example.insecureasymmetriccrypto.InsecureAsymmetricCipherBBCase1: void go()>", ConstraintError.class, 1);
-		setErrorsCount("<example.insecureasymmetriccrypto.InsecureAsymmetricCipherBBCase1: void go()>", RequiredPredicateError.class, 2);
+		setErrorsCount("<example.insecureasymmetriccrypto.InsecureAsymmetricCipherBBCase1: void go()>", RequiredPredicateError.class, 5);
 		
 		scanner.exec();
 		assertErrors();

--- a/CryptoAnalysis/src/test/java/tests/headless/IgnoreSectionsTest.java
+++ b/CryptoAnalysis/src/test/java/tests/headless/IgnoreSectionsTest.java
@@ -28,7 +28,7 @@ public class IgnoreSectionsTest extends AbstractHeadlessTest {
 		setErrorsCount("<example.ConstraintErrorExample: void main(java.lang.String[])>", IncompleteOperationError.class, 1);
 		setErrorsCount("<example.IncompleteOperationErrorExample: void main(java.lang.String[])>", IncompleteOperationError.class, 1);
 		setErrorsCount("<example.PredicateMissingExample: void main(java.lang.String[])>", ConstraintError.class, 1);
-		setErrorsCount("<example.PredicateMissingExample: void main(java.lang.String[])>", RequiredPredicateError.class, 1);
+		setErrorsCount("<example.PredicateMissingExample: void main(java.lang.String[])>", RequiredPredicateError.class, 2);
 		setErrorsCount("<example.TypestateErrorExample: void main(java.lang.String[])>", TypestateError.class, 1);
 
 		scanner.exec();
@@ -78,7 +78,7 @@ public class IgnoreSectionsTest extends AbstractHeadlessTest {
 		setErrorsCount("<example.IncompleteOperationErrorExample: void main(java.lang.String[])>", IncompleteOperationError.class, 0);
 
 		setErrorsCount("<example.PredicateMissingExample: void main(java.lang.String[])>", ConstraintError.class, 1);
-		setErrorsCount("<example.PredicateMissingExample: void main(java.lang.String[])>", RequiredPredicateError.class, 1);
+		setErrorsCount("<example.PredicateMissingExample: void main(java.lang.String[])>", RequiredPredicateError.class, 2);
 		setErrorsCount("<example.TypestateErrorExample: void main(java.lang.String[])>", TypestateError.class, 1);
 
 		scanner.exec();

--- a/CryptoAnalysis/src/test/java/tests/headless/MessageDigestExampleTest.java
+++ b/CryptoAnalysis/src/test/java/tests/headless/MessageDigestExampleTest.java
@@ -16,7 +16,7 @@ public class MessageDigestExampleTest extends AbstractHeadlessTest{
 		HeadlessCryptoScanner scanner = createScanner(mavenProject);
 		
 		//false positive
-		setErrorsCount("<MessageDigestExample.MessageDigestExample.Main: java.lang.String getSHA256(java.io.InputStream)>", IncompleteOperationError.class, 2);
+		setErrorsCount("<MessageDigestExample.MessageDigestExample.Main: java.lang.String getSHA256(java.io.InputStream)>", IncompleteOperationError.class, 3);
 		
 		scanner.exec();
 		assertErrors();

--- a/CryptoAnalysis/src/test/java/tests/headless/ReportedIssueTest.java
+++ b/CryptoAnalysis/src/test/java/tests/headless/ReportedIssueTest.java
@@ -24,7 +24,7 @@ public class ReportedIssueTest extends AbstractHeadlessTest {
 		setErrorsCount("<issue81.Encryption: byte[] encrypt(byte[],javax.crypto.SecretKey)>", RequiredPredicateError.class, 1);
 
 		setErrorsCount("<issue81.Encryption: javax.crypto.SecretKey generateKey(java.lang.String)>", IncompleteOperationError.class, 1);
-		setErrorsCount("<issue81.Encryption: javax.crypto.SecretKey generateKey(java.lang.String)>", RequiredPredicateError.class, 3);
+		setErrorsCount("<issue81.Encryption: javax.crypto.SecretKey generateKey(java.lang.String)>", RequiredPredicateError.class, 4);
 		setErrorsCount("<issue81.Encryption: javax.crypto.SecretKey generateKey(java.lang.String)>", NeverTypeOfError.class, 1);
 		setErrorsCount("<issue81.Encryption: javax.crypto.SecretKey generateKey(java.lang.String)>", ConstraintError.class, 1);
 		setErrorsCount("<issue81.Encryption: javax.crypto.SecretKey generateKey(java.lang.String)>", HardCodedError.class, 1);
@@ -34,7 +34,7 @@ public class ReportedIssueTest extends AbstractHeadlessTest {
 		setErrorsCount("<issue81.Main: void main(java.lang.String[])>", HardCodedError.class, 1);
 
 		setErrorsCount("<issuecognicrypt210.CogniCryptSecretKeySpec: void main(java.lang.String[])>", ConstraintError.class, 0);
-		setErrorsCount("<issuecognicrypt210.CogniCryptSecretKeySpec: void main(java.lang.String[])>", RequiredPredicateError.class, 2);
+		setErrorsCount("<issuecognicrypt210.CogniCryptSecretKeySpec: void main(java.lang.String[])>", RequiredPredicateError.class, 3);
 		setErrorsCount("<issuecognicrypt210.CogniCryptSecretKeySpec: void main(java.lang.String[])>", HardCodedError.class, 1);
 
 		setErrorsCount("<issue70.ClientProtocolDecoder: byte[] decryptAES(byte[])>", ConstraintError.class, 1);
@@ -43,7 +43,7 @@ public class ReportedIssueTest extends AbstractHeadlessTest {
 		setErrorsCount("<issue68.Main: void main(java.lang.String[])>", IncompleteOperationError.class, 2);
 
 		setErrorsCount("<issue68.AESCryptor: byte[] getKey(java.lang.String)>", NeverTypeOfError.class, 1);
-		setErrorsCount("<issue68.AESCryptor: byte[] getKey(java.lang.String)>", RequiredPredicateError.class, 2);
+		setErrorsCount("<issue68.AESCryptor: byte[] getKey(java.lang.String)>", RequiredPredicateError.class, 3);
 		setErrorsCount("<issue68.AESCryptor: byte[] getKey(java.lang.String)>", IncompleteOperationError.class, 1);
 		setErrorsCount("<issue68.AESCryptor: byte[] getKey(java.lang.String)>", HardCodedError.class, 1);
 		setErrorsCount("<issue68.AESCryptor: javax.crypto.SecretKeyFactory getFactory()>", ConstraintError.class, 1);
@@ -53,6 +53,7 @@ public class ReportedIssueTest extends AbstractHeadlessTest {
 		setErrorsCount("<issue68.AESCryptor: byte[] decryptImpl(byte[])>", RequiredPredicateError.class, 2);
 
 		setErrorsCount("<issue49.Main: java.security.PrivateKey getPrivateKey()>", ConstraintError.class, 1);
+		setErrorsCount("<issue49.Main: java.security.PrivateKey getPrivateKey()>", RequiredPredicateError.class, 2);
 		setErrorsCount("<issue49.Main: byte[] sign(java.lang.String)>", RequiredPredicateError.class, 1);
 
 		setErrorsCount("<issue103.Main: void main(java.lang.String[])>", RequiredPredicateError.class, 4);

--- a/CryptoAnalysis/src/test/java/tests/headless/SootJava9ConfigurationTest.java
+++ b/CryptoAnalysis/src/test/java/tests/headless/SootJava9ConfigurationTest.java
@@ -50,7 +50,7 @@ public class SootJava9ConfigurationTest extends AbstractHeadlessTest {
 		MavenProject mavenProject = createAndCompile(mavenProjectPath);
 		HeadlessCryptoScanner scanner = createScanner(mavenProject, Ruleset.JavaCryptographicArchitecture);
 
-		setErrorsCount("<example.PredicateMissingExample: void main(java.lang.String[])>", RequiredPredicateError.class, 1);
+		setErrorsCount("<example.PredicateMissingExample: void main(java.lang.String[])>", RequiredPredicateError.class, 2);
 		setErrorsCount("<example.PredicateMissingExample: void main(java.lang.String[])>", ConstraintError.class, 1);
 		setErrorsCount("<example.IncompleOperationErrorExample: void main(java.lang.String[])>", IncompleteOperationError.class, 1);
 		setErrorsCount("<example.ConstraintErrorExample: void main(java.lang.String[])>", ConstraintError.class, 1);

--- a/CryptoAnalysis/src/test/java/tests/headless/StaticAnalysisDemoTest.java
+++ b/CryptoAnalysis/src/test/java/tests/headless/StaticAnalysisDemoTest.java
@@ -24,7 +24,7 @@ public class StaticAnalysisDemoTest extends AbstractHeadlessTest {
 		setErrorsCount("<example.ConstraintErrorExample: void main(java.lang.String[])>", IncompleteOperationError.class, 1);
 		setErrorsCount("<example.fixed.ConstraintErrorExample: void main(java.lang.String[])>", IncompleteOperationError.class, 1);
 		
-		setErrorsCount("<example.PredicateMissingExample: void main(java.lang.String[])>", RequiredPredicateError.class, 1);
+		setErrorsCount("<example.PredicateMissingExample: void main(java.lang.String[])>", RequiredPredicateError.class, 2);
 		setErrorsCount("<example.PredicateMissingExample: void main(java.lang.String[])>", ConstraintError.class, 1);
 		setErrorsCount("<example.TypestateErrorExample: void main(java.lang.String[])>", TypestateError.class, 1);
 		setErrorsCount("<example.IncompleOperationErrorExample: void main(java.lang.String[])>", IncompleteOperationError.class, 1);
@@ -44,6 +44,7 @@ public class StaticAnalysisDemoTest extends AbstractHeadlessTest {
 		setErrorsCount("<main.Msg: byte[] sign(java.lang.String)>", ConstraintError.class, 1);
 		setErrorsCount("<main.Msg: byte[] sign(java.lang.String)>", RequiredPredicateError.class, 1);
 		setErrorsCount("<main.Msg: java.security.PrivateKey getPrivateKey()>", ConstraintError.class, 1);
+		setErrorsCount("<main.Msg: java.security.PrivateKey getPrivateKey()>", RequiredPredicateError.class, 2);
 
 		setErrorsCount("<main.Msg: void encryptAlgFromField()>", ConstraintError.class, 1);
 		setErrorsCount("<main.Msg: void encryptAlgFromField()>", IncompleteOperationError.class, 1);
@@ -58,7 +59,7 @@ public class StaticAnalysisDemoTest extends AbstractHeadlessTest {
 		setErrorsCount("<main.Encrypt: void incorrectBigInteger()>", RequiredPredicateError.class, 1);
 		
 		setErrorsCount("<main.Encrypt: void incorrect()>", ConstraintError.class, 2);
-		setErrorsCount("<main.Encrypt: void incorrect()>", RequiredPredicateError.class, 1);
+		setErrorsCount("<main.Encrypt: void incorrect()>", RequiredPredicateError.class, 2);
 
 		scanner.exec();
 		assertErrors();
@@ -99,7 +100,7 @@ public class StaticAnalysisDemoTest extends AbstractHeadlessTest {
 
 
 		//TODO this is a spurious finding. What happens here?
-		setErrorsCount("<Crypto.PWHasher: java.lang.Boolean verifyPWHash(char[],java.lang.String)>", RequiredPredicateError.class, 2);
+		setErrorsCount("<Crypto.PWHasher: java.lang.Boolean verifyPWHash(char[],java.lang.String)>", RequiredPredicateError.class, 3);
 
 
 		setErrorsCount("<main.Main: void incorrectKeyForWrongCipher()>", ConstraintError.class, 1);

--- a/CryptoAnalysis/src/test/java/tests/pattern/IssuesTest.java
+++ b/CryptoAnalysis/src/test/java/tests/pattern/IssuesTest.java
@@ -84,7 +84,7 @@ public class IssuesTest extends UsagePatternTestingFramework {
 		PublicKey pubkey2 = kf.generatePublic(keySpec2);
 		Assertions.notHasEnsuredPredicate(pubkey2);
 
-		Assertions.predicateErrors(4);
+		Assertions.predicateErrors(6);
 	}
 
 }

--- a/CryptoAnalysis/src/test/resources/testrules/requiredPredicateWithThis/SimpleTarget.crysl
+++ b/CryptoAnalysis/src/test/resources/testrules/requiredPredicateWithThis/SimpleTarget.crysl
@@ -1,0 +1,11 @@
+SPEC tests.custom.predicate.SimpleTarget
+
+EVENTS
+    Con: SimpleTarget();
+    dN: doNothing();
+
+ORDER
+    Con, dN*
+
+REQUIRES
+    generatedTarget[this];

--- a/CryptoAnalysis/src/test/resources/testrules/requiredPredicateWithThis/Source.crysl
+++ b/CryptoAnalysis/src/test/resources/testrules/requiredPredicateWithThis/Source.crysl
@@ -1,0 +1,24 @@
+SPEC tests.custom.predicate.Source
+
+OBJECTS
+    boolean constraintError;
+    tests.custom.predicate.SimpleTarget target1;
+    tests.custom.predicate.TargetWithAlternatives target2;
+
+EVENTS
+    Con: Source();
+    causeError: causeConstraintError(constraintError);
+    passPred1: target1 = generateTarget();
+    passPred2: target2 = generateTargetWithAlternatives();
+
+    passPred := passPred1 | passPred2;
+
+ORDER
+    Con, causeError, passPred
+
+CONSTRAINTS
+    constraintError in {false};
+
+ENSURES
+    generatedTarget[target1];
+    generatedTargetWithAlternatives[target2];

--- a/CryptoAnalysis/src/test/resources/testrules/requiredPredicateWithThis/TargetWithDifferentAlternatives.crysl
+++ b/CryptoAnalysis/src/test/resources/testrules/requiredPredicateWithThis/TargetWithDifferentAlternatives.crysl
@@ -1,0 +1,14 @@
+SPEC tests.custom.predicate.TargetWithAlternatives
+
+OBJECTS
+    java.lang.String word;
+
+EVENTS
+    Con: TargetWithAlternatives();
+    dN: doNothing(word);
+
+ORDER
+    Con, dN*
+
+REQUIRES
+    generatedTargetWithAlternatives[this] || generatedWord[word];

--- a/CryptoAnalysis/src/test/resources/testrules/requiredPredicateWithThis/UsingTarget.crysl
+++ b/CryptoAnalysis/src/test/resources/testrules/requiredPredicateWithThis/UsingTarget.crysl
@@ -1,0 +1,22 @@
+SPEC tests.custom.predicate.UsingTarget
+
+OBJECTS
+    tests.custom.predicate.SimpleTarget target1;
+    tests.custom.predicate.TargetWithAlternatives target2;
+
+EVENTS
+    Con: UsingTarget();
+    uT1: useTarget(target1);
+    uT2: useTarget(target2);
+
+    uT := uT1 | uT2;
+
+ORDER
+    Con, uT
+
+REQUIRES
+    generatedTarget[target1];
+    generatedTargetWithAlternatives[target2];
+
+ENSURES
+    usedTarget[this];


### PR DESCRIPTION
This PR adds the basic functionality to collect subsequent errors. Each error references preceding and subsequent errors, which improves the overall error detection, and which allows comprehending errors. In addition to that, the analysis is able to parse and deal with predicates that contain the keyword `this`. An example could look like this:
```
KeyGenerator kg = KeyGenerator.getInstance("AES");
kg.initialize(64);                    // constraint error
SecretKey key = kg.generateKey();     // the key is not generated securely
```
A key size of `64` is not allowed. Therefore, the analysis reports a `ConstraintError` for `KeyGenerator` and `kg` is not secure. Hence, the returned key from `generateKey()` is not secure, too, and a `RequiredPredicateError` is reported. This `RequiredPredicateError` references the previous `ConstraintError` and allows reasoning that the `RequiredPredicateError` is caused by the `ConstraintError` (and vice versa: the `ConstraintError` references the `RequiredPredicateError`, that is, the `ConstraintError` causes the `RequiredPredicateError`).

The idea and logic was implemented by @marvinvo and most changes were taken from his work: https://github.com/marvinvo/CryptoAnalysis

Note: Currently, preceding and subsequent errors are not included in the reports, yet. They are only stored internally, which still allows testing the functionality.