### PR TITLE
Improvements for the GitHub Annotations limit

### DIFF
--- a/CryptoAnalysis/src/main/java/crypto/reporting/GitHubAnnotationReporter.java
+++ b/CryptoAnalysis/src/main/java/crypto/reporting/GitHubAnnotationReporter.java
@@ -23,7 +23,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.StringJoiner;
 
-public class GitHubAnnotationReporter extends Reporter  {
+public class GitHubAnnotationReporter extends CommandLineReporter {
     /**
      * Path to relate paths in the analyzed jar and the source tree.
      * <p>
@@ -47,13 +47,15 @@ public class GitHubAnnotationReporter extends Reporter  {
      *                                  to false, no statistics will be output.
      */
     public GitHubAnnotationReporter(String softwareID, List<CrySLRule> rules, long callgraphConstructionTime, boolean includeStatistics) {
-        super(null, softwareID, rules, callgraphConstructionTime, includeStatistics);
+        super(softwareID, rules, callgraphConstructionTime, includeStatistics);
 
         basePath = getInput("basePath");
     }
 
     @Override
     public void handleAnalysisResults() {
+        System.out.println("::group::Annotations");
+
         // report errors on individual lines
         for (Table.Cell<SootClass, SootMethod, Set<AbstractError>> cell : errorMarkers.cellSet()) {
             SootClass clazz = cell.getRowKey();
@@ -130,6 +132,10 @@ public class GitHubAnnotationReporter extends Reporter  {
         if (errorCount != 0) {
             HeadlessCryptoScanner.exitCode = 1;
         }
+
+        System.out.println("::endgroup::");
+
+        super.handleAnalysisResults();
     }
 
     private Path classToSourcePath(SootClass clazz) {

--- a/CryptoAnalysis/src/main/java/crypto/reporting/GitHubAnnotationReporter.java
+++ b/CryptoAnalysis/src/main/java/crypto/reporting/GitHubAnnotationReporter.java
@@ -115,6 +115,16 @@ public class GitHubAnnotationReporter extends Reporter  {
             summary.append(String.format("DataflowVisitedMethods: %d\n", statistics.getDataflowVisitedMethods()));
         }
 
+        // GitHub only displays 10 error annotations and silently drops the rest.
+        // https://github.com/orgs/community/discussions/26680
+        // https://github.com/orgs/community/discussions/68471
+        if (errorCount > 10) {
+            String missingAnnotationsMessage = "There are more violations than the GitHub annotations interface displays. Please check the log for additional violations.";
+
+            System.out.println("::warning ::" + missingAnnotationsMessage);
+            summary.append("\nWarning: ").append(missingAnnotationsMessage).append("\n");
+        }
+
         setSummary(summary.toString());
 
         if (errorCount != 0) {

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ CogniCrypt<sub>SAST</sub> supports different report formats, which can be set by
 - `SARIF`: The report is written to the JSON file `CryptoAnalysis-Report.json`. The content is formatted in the SARIF format.
 - `CSV`: The report is written to the CSV file `CryptoAnalysis-Report.csv`. The content is formatted in the CSV format.
 - `CSV_SUMMARY`: The report is written to the file `CryptoAnalysis-Report-Summary.csv` and contains a summary of the analysis results. Compared to the `CSV` format, this format does not provide concrete information about the errors, it only lists the amount of each misuse type. This option was previously implemented by the `CSV` option, which has been changed to provide more detailed information about the errors in the CSV format.
+- `GITHUB_ANNOTATION`: Works like `CMD` but also outputs all violations as annotations when running inside as a GitHub Action.
 
 If the `--reportformat` option is not specified, CogniCrypt<sub>SAST</sub> defaults to the `CMD` option. It also allows the usage of multiple different formats for the same analysis (e.g. `--reportformat CMD,TXT,CSV` creates a report, which is printed to the command line and is written to a text and CSV file). If the option `--reportPath <directory_location_for_cryptoanalysis_report>` is set, the reports are created in the specified directory.
 

--- a/action.yml
+++ b/action.yml
@@ -94,7 +94,10 @@ runs:
       if: steps.cache.outputs.cache-hit != 'true'
       continue-on-error: true
       shell: bash
-      run: mvn dependency:copy -Dartifact=de.fraunhofer.iem:CryptoAnalysis:${{ env.GH_ACTION_REF }}:jar:jar-with-dependencies -DoutputDirectory=CryptoAnalysis/build
+      run: |
+        echo "::group::Download"
+        mvn dependency:copy -Dartifact=de.fraunhofer.iem:CryptoAnalysis:${{ env.GH_ACTION_REF }}:jar:jar-with-dependencies -DoutputDirectory=CryptoAnalysis/build
+        echo "::endgroup::"
       working-directory: CryptoAnalysisBuild_98e04be6
       env:
         GH_ACTION_REF: ${{ github.action_ref }}
@@ -104,7 +107,10 @@ runs:
     - name: Compile CryptoAnalysis
       if: steps.cache.outputs.cache-hit != 'true' && steps.download.outcome != 'success'
       shell: bash
-      run: mvn package -DskipTests=true
+      run: |
+        echo "::group::Compile"
+        mvn package -DskipTests=true
+        echo "::endgroup::"
       working-directory: CryptoAnalysisBuild_98e04be6
 
     - name: Copy JAR to convenient path


### PR DESCRIPTION
GitHub only displays 10 error annotations and silently drops the rest.
https://github.com/orgs/community/discussions/26680
https://github.com/orgs/community/discussions/68471

This PR adds a warning message when more than 10 violations are found.
Additionally, the `GitHubAnnotationReporter` now also outputs the normal command line report, so that the log contains all necessary information when not everything can be displayed using annotations.
The action setup also uses some grouping now to de-clutter the log.

Example run with more than 10 violations:
https://github.com/Timbals/CryptoAnalysis-demo/actions/runs/8086032882