### PR TITLE
Swap Type and Name of CrySLObject for instanceOf and neverTypeOf predicates

### DIFF
--- a/CryptoAnalysis/src/main/java/crypto/constraints/PredicateConstraint.java
+++ b/CryptoAnalysis/src/main/java/crypto/constraints/PredicateConstraint.java
@@ -111,7 +111,7 @@ public class PredicateConstraint extends EvaluableConstraint {
 					if (cs.getVarName().equals(varName)) {
 						Collection<Type> vals = context.getPropagatedTypes().get(cs);
 						for (Type t : vals) {
-							if (t.toQuotedString().equals(parameters.get(1).getName())) {
+							if (t.toQuotedString().equals(((CrySLObject) parameters.get(1)).getJavaType())) {
 								for (ExtractedValue v : context.getParsAndVals().get(cs)) {
 									errors.add(
 											new NeverTypeOfError(new CallSiteWithExtractedValue(cs, v), context.getClassSpec().getRule(),
@@ -152,8 +152,9 @@ public class PredicateConstraint extends EvaluableConstraint {
 				for (CallSiteWithParamIndex cs : context.getParameterAnalysisQuerySites()) {
 					if (cs.getVarName().equals(varName)) {
 						Collection<Type> vals = context.getPropagatedTypes().get(cs);
-						if (!vals.parallelStream().anyMatch(e -> isSubType(e.toQuotedString(), parameters.get(1).getName())
-								|| isSubType(parameters.get(1).getName(), e.toQuotedString()))) {
+						String javaType = ((CrySLObject) parameters.get(1)).getJavaType();
+
+						if (!vals.parallelStream().anyMatch(e -> isSubType(e.toQuotedString(), javaType) || isSubType(javaType, e.toQuotedString()))) {
 							for (ExtractedValue v : context.getParsAndVals().get(cs)) {
 								errors.add(
 										new InstanceOfError(new CallSiteWithExtractedValue(cs, v), context.getClassSpec().getRule(),

--- a/CryptoAnalysis/src/main/java/crypto/cryslhandler/CrySLModelReader.java
+++ b/CryptoAnalysis/src/main/java/crypto/cryslhandler/CrySLModelReader.java
@@ -626,7 +626,7 @@ public class CrySLModelReader {
 			case NEVER_TYPE_OF:
 				parameters = Lists.newArrayList(
 						CrySLReaderUtils.toCrySLObject(builtinPredicate.getObject()),
-						new CrySLObject(builtinPredicate.getType().getQualifiedName(), NULL));
+						new CrySLObject(NULL, builtinPredicate.getType().getQualifiedName()));
 				break;
 
 			case NOT_HARD_CODED:


### PR DESCRIPTION
The second paramter of `instanceOf` and `neverTypeOf` is always a type (e.g. `javax.crypto.SecretKey`) and no name. However, internally the type was stored in the name field and not the type field of a `CrySLObject`. Changing type and name does not influence the analysis, but adds consistency. Detected by @svenfeld 