### PR TITLE
Fix incomplete operation errors

### DIFF
--- a/CryptoAnalysis/src/test/java/test/assertions/Assertions.java
+++ b/CryptoAnalysis/src/test/java/test/assertions/Assertions.java
@@ -36,6 +36,8 @@ public class Assertions {
 
 	public static void typestateErrors(int i) {}
 
+	public static void incompleteOperationErrors(int i) {}
+
 	public static void dependentError(int thisErrorNr) {}
 
 	public static void dependentError(int thisErrorNr, int precedingError1) {}

--- a/CryptoAnalysis/src/test/java/test/assertions/IncompleteOperationErrorCountAssertion.java
+++ b/CryptoAnalysis/src/test/java/test/assertions/IncompleteOperationErrorCountAssertion.java
@@ -1,0 +1,32 @@
+package test.assertions;
+
+import test.Assertion;
+
+public class IncompleteOperationErrorCountAssertion implements Assertion {
+
+    private int expectedErrorCounts;
+    private int actualErrorCounts;
+
+    public IncompleteOperationErrorCountAssertion(int numberOfCounts) {
+        this.expectedErrorCounts = numberOfCounts;
+    }
+
+    public void increaseCount(){
+        actualErrorCounts++;
+    }
+
+    @Override
+    public boolean isSatisfied() {
+        return expectedErrorCounts <= actualErrorCounts;
+    }
+
+    @Override
+    public boolean isImprecise() {
+        return expectedErrorCounts != actualErrorCounts;
+    }
+
+    @Override
+    public String toString() {
+        return "Expected " + expectedErrorCounts + " incomplete operation errors, but got " + actualErrorCounts;
+    }
+}

--- a/CryptoAnalysis/src/test/java/tests/custom/incompleteoperation/IncompleteOperationTest.java
+++ b/CryptoAnalysis/src/test/java/tests/custom/incompleteoperation/IncompleteOperationTest.java
@@ -1,0 +1,115 @@
+package tests.custom.incompleteoperation;
+
+import crypto.analysis.CrySLRulesetSelector.Ruleset;
+import org.junit.Test;
+import test.UsagePatternTestingFramework;
+import test.assertions.Assertions;
+
+public class IncompleteOperationTest extends UsagePatternTestingFramework {
+
+    @Override
+    public Ruleset getRuleSet() {
+        return Ruleset.CustomRules;
+    }
+
+    @Override
+    public String getRulesetPath() {
+        return "incompleteOperation";
+    }
+
+    @Test
+    public void testNoIncompleteOperation() {
+        Operations operations1 = new Operations();
+        operations1.operation1();
+        operations1.operation2();
+        operations1.operation3();
+        operations1.operation4();
+
+        Operations operations2 = new Operations();
+        operations2.operation1();
+        operations2.operation2();
+        operations2.operation3();
+        // operation 4 is optional, i.e. no incomplete operation
+
+        Assertions.incompleteOperationErrors(0);
+    }
+
+    @Test
+    public void testMissingOperation() {
+        Operations operations = new Operations();
+        operations.operation1();
+        operations.operation2();
+        // operation3 is missing
+
+        Assertions.incompleteOperationErrors(1);
+    }
+
+    @Test
+    public void testSingleDataflowPathWithIncompleteOperation() {
+        Operations operations = new Operations();
+        operations.operation1();
+        operations.operation2();
+
+        // Dataflow path without operation3 exists => incomplete operation
+        if (Math.random() > 0.5) {
+            operations.operation3();
+        }
+
+        Assertions.incompleteOperationErrors(1);
+    }
+
+    @Test
+    public void testMultipleDataflowPathsWithIncompleteOperations() {
+        Operations operations = new Operations();
+        operations.operation1();
+
+        // On both dataflow paths a call two operation3 is missing => 2 incomplete operations
+        if (Math.random() > 0.5) {
+            operations.operation2();
+        } else {
+            operations.operation2();
+        }
+
+        Assertions.incompleteOperationErrors(2);
+    }
+
+    @Test
+    public void testMultipleDataflowPathsWithoutIncompleteOperations() {
+        Operations operations = new Operations();
+        operations.operation1();
+
+        // Both dataflow path are completed with operation3
+        if (Math.random() > 0.5) {
+            operations.operation2();
+        } else {
+            operations.operation2();
+        }
+        operations.operation3();
+
+        Assertions.incompleteOperationErrors(0);
+    }
+
+    @Test
+    public void testIncompleteOperationWithLoops() {
+        Operations operations1 = new Operations();
+        operations1.operation1();
+        operations1.operation2();
+
+        // Dataflow path without call to operation3
+        while (Math.random() > 0.5) {
+            operations1.operation3();
+        }
+
+        Operations operations2 = new Operations();
+        operations2.operation1();
+        operations2.operation2();
+
+        // Dataflow path without call to operation3
+        for (int i = 0; i < 1; i++) {
+            operations2.operation3();
+        }
+
+        Assertions.incompleteOperationErrors(2);
+    }
+
+}

--- a/CryptoAnalysis/src/test/java/tests/custom/incompleteoperation/Operations.java
+++ b/CryptoAnalysis/src/test/java/tests/custom/incompleteoperation/Operations.java
@@ -1,0 +1,12 @@
+package tests.custom.incompleteoperation;
+
+public class Operations {
+
+    public void operation1() {}
+
+    public void operation2() {}
+
+    public void operation3() {}
+
+    public void operation4() {}
+}

--- a/CryptoAnalysis/src/test/java/tests/headless/BouncyCastleHeadlessTest.java
+++ b/CryptoAnalysis/src/test/java/tests/headless/BouncyCastleHeadlessTest.java
@@ -35,7 +35,7 @@ public class BouncyCastleHeadlessTest extends AbstractHeadlessTest {
 		setErrorsCount("<gwt_crypto.SkeinMacTest: void performTestOne()>", RequiredPredicateError.class, 1);
 		
 		setErrorsCount("<bunkr.PBKDF2Descriptor: int calculateRounds(int)>", TypestateError.class, 1);
-		setErrorsCount("<bunkr.PBKDF2Descriptor: int calculateRounds(int)>", IncompleteOperationError.class, 2);
+		setErrorsCount("<bunkr.PBKDF2Descriptor: int calculateRounds(int)>", IncompleteOperationError.class, 1);
 		
 		setErrorsCount("<pattern.MacTest: void testMac1()>", RequiredPredicateError.class, 1);
 		setErrorsCount("<pattern.MacTest: void testMac2()>", RequiredPredicateError.class, 3);

--- a/CryptoAnalysis/src/test/java/tests/headless/BragaCryptoGoodusesTest.java
+++ b/CryptoAnalysis/src/test/java/tests/headless/BragaCryptoGoodusesTest.java
@@ -46,7 +46,7 @@ public class BragaCryptoGoodusesTest extends AbstractHeadlessTest {
 		setErrorsCount("<example.DefinedProvider6: void main(java.lang.String[])>", ConstraintError.class, 1);
 		setErrorsCount("<example.DefinedProvider6: void main(java.lang.String[])>", TypestateError.class, 1);
 		setErrorsCount("<example.DefinedProvider7: void main(java.lang.String[])>", ConstraintError.class, 1);
-		setErrorsCount("<example.DefinedProvider7: void main(java.lang.String[])>", IncompleteOperationError.class, 4);
+		setErrorsCount("<example.DefinedProvider7: void main(java.lang.String[])>", IncompleteOperationError.class, 2);
 		setErrorsCount("<example.DefinedProvider7: void main(java.lang.String[])>", RequiredPredicateError.class, 5);
 
 		scanner.exec();
@@ -67,7 +67,7 @@ public class BragaCryptoGoodusesTest extends AbstractHeadlessTest {
 		setErrorsCount("<example.PBEwLargeCountAndRandomSalt: void main(java.lang.String[])>", RequiredPredicateError.class, 4);
 		setErrorsCount("<example.PBEwLargeCountAndRandomSalt: void main(java.lang.String[])>", ForbiddenMethodError.class, 1);
 		setErrorsCount("<example.DoNotSaveToString: void main(java.lang.String[])>", TypestateError.class, 1);
-		setErrorsCount("<example.GenerateRandomIV: void main(java.lang.String[])>", IncompleteOperationError.class, 4);
+		setErrorsCount("<example.GenerateRandomIV: void main(java.lang.String[])>", IncompleteOperationError.class, 2);
 		setErrorsCount("<example.GenerateRandomIV: void main(java.lang.String[])>", RequiredPredicateError.class, 4);
 		setErrorsCount("<example.GenerateRandomIV: void main(java.lang.String[])>", TypestateError.class, 2);
 
@@ -103,25 +103,25 @@ public class BragaCryptoGoodusesTest extends AbstractHeadlessTest {
 		HeadlessCryptoScanner scanner = createScanner(mavenProject);
 
 		// positive test case
-		setErrorsCount("<example.UseOAEPForRSA: void positiveTestCase()>", IncompleteOperationError.class, 4);
+		setErrorsCount("<example.UseOAEPForRSA: void positiveTestCase()>", IncompleteOperationError.class, 2);
 		setErrorsCount("<example.UseOAEPForRSA: void positiveTestCase()>", RequiredPredicateError.class, 0);
 		setErrorsCount("<example.UseOAEPForRSA: void positiveTestCase()>", ConstraintError.class, 0);
 		setErrorsCount("<example.UseOAEPForRSA: void positiveTestCase()>", TypestateError.class, 0);
 		
 		// negative test case
-		setErrorsCount("<example.UseOAEPForRSA: void negativeTestCase()>", IncompleteOperationError.class, 4);
+		setErrorsCount("<example.UseOAEPForRSA: void negativeTestCase()>", IncompleteOperationError.class, 2);
 		setErrorsCount("<example.UseOAEPForRSA: void negativeTestCase()>", RequiredPredicateError.class, 5);
 		setErrorsCount("<example.UseOAEPForRSA: void negativeTestCase()>", ConstraintError.class, 1);
 		setErrorsCount("<example.UseOAEPForRSA: void negativeTestCase()>", TypestateError.class, 0);
 		
 		// positive test case
-		setErrorsCount("<example.UsePKCS1ForRSA: void positiveTestCase()>", IncompleteOperationError.class, 4);
+		setErrorsCount("<example.UsePKCS1ForRSA: void positiveTestCase()>", IncompleteOperationError.class, 2);
 		setErrorsCount("<example.UsePKCS1ForRSA: void positiveTestCase()>", RequiredPredicateError.class, 0);
 		setErrorsCount("<example.UsePKCS1ForRSA: void positiveTestCase()>", ConstraintError.class, 0);
 		setErrorsCount("<example.UsePKCS1ForRSA: void positiveTestCase()>", TypestateError.class, 0);
 
 		// negative test case
-		setErrorsCount("<example.UsePKCS1ForRSA: void negativeTestCase()>", IncompleteOperationError.class, 4);
+		setErrorsCount("<example.UsePKCS1ForRSA: void negativeTestCase()>", IncompleteOperationError.class, 2);
 		setErrorsCount("<example.UsePKCS1ForRSA: void negativeTestCase()>", RequiredPredicateError.class, 5);
 		setErrorsCount("<example.UsePKCS1ForRSA: void negativeTestCase()>", ConstraintError.class, 1);
 		setErrorsCount("<example.UsePKCS1ForRSA: void negativeTestCase()>", TypestateError.class, 0);
@@ -261,10 +261,10 @@ public class BragaCryptoGoodusesTest extends AbstractHeadlessTest {
 		setErrorsCount("<example.UseQualifiedNameForPBE1: void main(java.lang.String[])>", ForbiddenMethodError.class, 1);
 		setErrorsCount("<example.UseQualifiedNameForPBE1: void main(java.lang.String[])>", TypestateError.class, 1);
 		setErrorsCount("<example.UseQualifiedNameForPBE1: void main(java.lang.String[])>", ConstraintError.class, 1);
-		setErrorsCount("<example.UseExplicitMode1: void main(java.lang.String[])>", IncompleteOperationError.class, 4);
+		setErrorsCount("<example.UseExplicitMode1: void main(java.lang.String[])>", IncompleteOperationError.class, 3);
 		setErrorsCount("<example.UseExplicitMode1: void main(java.lang.String[])>", RequiredPredicateError.class, 5);
 		setErrorsCount("<example.UseExplicitMode1: void main(java.lang.String[])>", TypestateError.class, 2);
-		setErrorsCount("<example.UseExplicitPadding1: void main(java.lang.String[])>", IncompleteOperationError.class, 4);
+		setErrorsCount("<example.UseExplicitPadding1: void main(java.lang.String[])>", IncompleteOperationError.class, 3);
 		setErrorsCount("<example.UseExplicitPadding1: void main(java.lang.String[])>", RequiredPredicateError.class, 5);
 		setErrorsCount("<example.UseExplicitPadding1: void main(java.lang.String[])>", TypestateError.class, 2);
 		
@@ -736,10 +736,10 @@ public class BragaCryptoGoodusesTest extends AbstractHeadlessTest {
 		setErrorsCount("<example.UseRandomIVsForCBC: void main(java.lang.String[])>", ConstraintError.class, 2);
 		setErrorsCount("<example.UseRandomIVsForCBC: void main(java.lang.String[])>", TypestateError.class, 2);
 		setErrorsCount("<example.UseRandomIVsForCFB: void main(java.lang.String[])>", RequiredPredicateError.class, 1);
-		setErrorsCount("<example.UseRandomIVsForCFB: void main(java.lang.String[])>", IncompleteOperationError.class, 4);
+		setErrorsCount("<example.UseRandomIVsForCFB: void main(java.lang.String[])>", IncompleteOperationError.class, 3);
 		setErrorsCount("<example.UseRandomIVsForCFB: void main(java.lang.String[])>", TypestateError.class, 2);
 		setErrorsCount("<example.UseRandomIVsForCFB128: void main(java.lang.String[])>", RequiredPredicateError.class, 1);
-		setErrorsCount("<example.UseRandomIVsForCFB128: void main(java.lang.String[])>", IncompleteOperationError.class, 4);
+		setErrorsCount("<example.UseRandomIVsForCFB128: void main(java.lang.String[])>", IncompleteOperationError.class, 3);
 		setErrorsCount("<example.UseRandomIVsForCFB128: void main(java.lang.String[])>", TypestateError.class, 2);
 		setErrorsCount("<example.UseRandomIVsForCFB128: void main(java.lang.String[])>", ConstraintError.class, 2);
 

--- a/CryptoAnalysis/src/test/java/tests/headless/BragaCryptoMisusesTest.java
+++ b/CryptoAnalysis/src/test/java/tests/headless/BragaCryptoMisusesTest.java
@@ -103,10 +103,10 @@ public class BragaCryptoMisusesTest extends AbstractHeadlessTest {
 
 		setErrorsCount("<cib.buggyIVgen.BuggyIVGen1: void main(java.lang.String[])>", TypestateError.class, 2);
 		setErrorsCount("<cib.buggyIVgen.BuggyIVGen1: void main(java.lang.String[])>", RequiredPredicateError.class, 7);
-		setErrorsCount("<cib.buggyIVgen.BuggyIVGen1: void main(java.lang.String[])>", IncompleteOperationError.class, 4);
+		setErrorsCount("<cib.buggyIVgen.BuggyIVGen1: void main(java.lang.String[])>", IncompleteOperationError.class, 2);
 		setErrorsCount("<cib.buggyIVgen.BuggyIVGen2: void main(java.lang.String[])>", TypestateError.class, 2);
 		setErrorsCount("<cib.buggyIVgen.BuggyIVGen2: void main(java.lang.String[])>", RequiredPredicateError.class, 7);
-		setErrorsCount("<cib.buggyIVgen.BuggyIVGen2: void main(java.lang.String[])>", IncompleteOperationError.class, 4);
+		setErrorsCount("<cib.buggyIVgen.BuggyIVGen2: void main(java.lang.String[])>", IncompleteOperationError.class, 2);
 
 		scanner.exec();
 		assertErrors();
@@ -120,10 +120,10 @@ public class BragaCryptoMisusesTest extends AbstractHeadlessTest {
 		MavenProject mavenProject = createAndCompile(mavenProjectPath);
 		HeadlessCryptoScanner scanner = createScanner(mavenProject);
 
-		setErrorsCount("<ivm.constantIV.FixedIV1: void main(java.lang.String[])>", IncompleteOperationError.class, 4);
+		setErrorsCount("<ivm.constantIV.FixedIV1: void main(java.lang.String[])>", IncompleteOperationError.class, 2);
 		setErrorsCount("<ivm.constantIV.FixedIV1: void main(java.lang.String[])>", TypestateError.class, 2);
 		setErrorsCount("<ivm.constantIV.FixedIV1: void main(java.lang.String[])>", RequiredPredicateError.class, 7);
-		setErrorsCount("<ivm.constantIV.FixedIV2: void main(java.lang.String[])>", IncompleteOperationError.class, 4);
+		setErrorsCount("<ivm.constantIV.FixedIV2: void main(java.lang.String[])>", IncompleteOperationError.class, 2);
 		setErrorsCount("<ivm.constantIV.FixedIV2: void main(java.lang.String[])>", TypestateError.class, 2);
 		setErrorsCount("<ivm.constantIV.FixedIV2: void main(java.lang.String[])>", RequiredPredicateError.class, 7);
 		setErrorsCount("<ivm.constantIV.SimpleIVConstant: void main(java.lang.String[])>", RequiredPredicateError.class, 1);
@@ -217,19 +217,19 @@ public class BragaCryptoMisusesTest extends AbstractHeadlessTest {
 
 		setErrorsCount("<pkc.enc.deterministicCrypto.DeterministicEncryptionRSA: void main(java.lang.String[])>", ForbiddenMethodError.class, 1);
 		setErrorsCount("<pkc.enc.deterministicCrypto.DeterministicEncryptionRSA: void main(java.lang.String[])>", ConstraintError.class, 1);
-		setErrorsCount("<pkc.enc.deterministicCrypto.DeterministicEncryptionRSA: void main(java.lang.String[])>", IncompleteOperationError.class, 4);
+		setErrorsCount("<pkc.enc.deterministicCrypto.DeterministicEncryptionRSA: void main(java.lang.String[])>", IncompleteOperationError.class, 2);
 		setErrorsCount("<pkc.enc.deterministicCrypto.DeterministicEncryptionRSA: void main(java.lang.String[])>", RequiredPredicateError.class, 5);
 		setErrorsCount("<pkc.enc.deterministicCrypto.DeterministicEncryptionRSA: void main(java.lang.String[])>", TypestateError.class, 0);
 		setErrorsCount("<pkc.enc.deterministicCrypto.DeterministicEncryptionRSA1: void main(java.lang.String[])>", ConstraintError.class, 3);
-		setErrorsCount("<pkc.enc.deterministicCrypto.DeterministicEncryptionRSA1: void main(java.lang.String[])>", IncompleteOperationError.class, 4);
+		setErrorsCount("<pkc.enc.deterministicCrypto.DeterministicEncryptionRSA1: void main(java.lang.String[])>", IncompleteOperationError.class, 2);
 		setErrorsCount("<pkc.enc.deterministicCrypto.DeterministicEncryptionRSA1: void main(java.lang.String[])>", RequiredPredicateError.class, 5);
 		setErrorsCount("<pkc.enc.deterministicCrypto.DeterministicEncryptionRSA1: void main(java.lang.String[])>", TypestateError.class, 0);
 		setErrorsCount("<pkc.enc.deterministicCrypto.DeterministicEncryptionRSA2: void main(java.lang.String[])>", ConstraintError.class, 1);
-		setErrorsCount("<pkc.enc.deterministicCrypto.DeterministicEncryptionRSA2: void main(java.lang.String[])>", IncompleteOperationError.class, 4);
+		setErrorsCount("<pkc.enc.deterministicCrypto.DeterministicEncryptionRSA2: void main(java.lang.String[])>", IncompleteOperationError.class, 2);
 		setErrorsCount("<pkc.enc.deterministicCrypto.DeterministicEncryptionRSA2: void main(java.lang.String[])>", RequiredPredicateError.class, 5);
 		setErrorsCount("<pkc.enc.deterministicCrypto.DeterministicEncryptionRSA2: void main(java.lang.String[])>", TypestateError.class, 0);
 		setErrorsCount("<pkc.enc.deterministicCrypto.DeterministicEncryptionRSA3: void main(java.lang.String[])>", ConstraintError.class, 1);
-		setErrorsCount("<pkc.enc.deterministicCrypto.DeterministicEncryptionRSA3: void main(java.lang.String[])>", IncompleteOperationError.class, 4);
+		setErrorsCount("<pkc.enc.deterministicCrypto.DeterministicEncryptionRSA3: void main(java.lang.String[])>", IncompleteOperationError.class, 2);
 		setErrorsCount("<pkc.enc.deterministicCrypto.DeterministicEncryptionRSA3: void main(java.lang.String[])>", RequiredPredicateError.class, 5);
 		setErrorsCount("<pkc.enc.deterministicCrypto.DeterministicEncryptionRSA3: void main(java.lang.String[])>", TypestateError.class, 0);
 
@@ -246,10 +246,10 @@ public class BragaCryptoMisusesTest extends AbstractHeadlessTest {
 		HeadlessCryptoScanner scanner = createScanner(mavenProject);
 
 		setErrorsCount("<wc.deterministicSymEnc.DeterministicEncryptionAESwECB1: void main(java.lang.String[])>", ConstraintError.class, 6);
-		setErrorsCount("<wc.deterministicSymEnc.DeterministicEncryptionAESwECB1: void main(java.lang.String[])>", IncompleteOperationError.class, 12);
+		setErrorsCount("<wc.deterministicSymEnc.DeterministicEncryptionAESwECB1: void main(java.lang.String[])>", IncompleteOperationError.class, 6);
 		setErrorsCount("<wc.deterministicSymEnc.DeterministicEncryptionAESwECB1: void main(java.lang.String[])>", TypestateError.class, 0);
 		setErrorsCount("<wc.deterministicSymEnc.DeterministicEncryptionAESwECB2: void main(java.lang.String[])>", ForbiddenMethodError.class, 1);
-		setErrorsCount("<wc.deterministicSymEnc.DeterministicEncryptionAESwECB2: void main(java.lang.String[])>", IncompleteOperationError.class, 4);
+		setErrorsCount("<wc.deterministicSymEnc.DeterministicEncryptionAESwECB2: void main(java.lang.String[])>", IncompleteOperationError.class, 2);
 		setErrorsCount("<wc.deterministicSymEnc.DeterministicEncryptionAESwECB2: void main(java.lang.String[])>", TypestateError.class, 0);
 
 		scanner.exec();
@@ -267,7 +267,7 @@ public class BragaCryptoMisusesTest extends AbstractHeadlessTest {
 		setErrorsCount("<br.fixedSeed.FixedSeed1: void main(java.lang.String[])>", TypestateError.class, 4);
 		setErrorsCount("<br.fixedSeed.FixedSeed1: void main(java.lang.String[])>", RequiredPredicateError.class, 10);
 		setErrorsCount("<br.fixedSeed.FixedSeed1: void main(java.lang.String[])>", ConstraintError.class, 2);
-		setErrorsCount("<br.fixedSeed.FixedSeed1: void main(java.lang.String[])>", IncompleteOperationError.class, 6);
+		setErrorsCount("<br.fixedSeed.FixedSeed1: void main(java.lang.String[])>", IncompleteOperationError.class, 4);
 		setErrorsCount("<br.fixedSeed.FixedSeed2: void main(java.lang.String[])>", RequiredPredicateError.class, 2);
 		setErrorsCount("<br.fixedSeed.FixedSeed3: void main(java.lang.String[])>", RequiredPredicateError.class, 2);
 		setErrorsCount("<br.fixedSeed.FixedSeed4: void main(java.lang.String[])>", RequiredPredicateError.class, 2);
@@ -425,13 +425,13 @@ public class BragaCryptoMisusesTest extends AbstractHeadlessTest {
 		setErrorsCount("<pdf.insecureDefault.InsecureDefaultOAEP: void negativeTestCase()>", TypestateError.class, 1);
 		
 		// positive test case
-		setErrorsCount("<pdf.insecureDefault.InsecureDefaultRSA: void positiveTestCase()>", IncompleteOperationError.class, 4);
+		setErrorsCount("<pdf.insecureDefault.InsecureDefaultRSA: void positiveTestCase()>", IncompleteOperationError.class, 2);
 		setErrorsCount("<pdf.insecureDefault.InsecureDefaultRSA: void positiveTestCase()>", RequiredPredicateError.class, 0);
 		setErrorsCount("<pdf.insecureDefault.InsecureDefaultRSA: void positiveTestCase()>", TypestateError.class, 0);
 		setErrorsCount("<pdf.insecureDefault.InsecureDefaultRSA: void positiveTestCase()>", ConstraintError.class, 0);
 		
 		// negative test case
-		setErrorsCount("<pdf.insecureDefault.InsecureDefaultRSA: void negativeTestCase()>", IncompleteOperationError.class, 4);
+		setErrorsCount("<pdf.insecureDefault.InsecureDefaultRSA: void negativeTestCase()>", IncompleteOperationError.class, 2);
 		setErrorsCount("<pdf.insecureDefault.InsecureDefaultRSA: void negativeTestCase()>", RequiredPredicateError.class, 5);
 		setErrorsCount("<pdf.insecureDefault.InsecureDefaultRSA: void negativeTestCase()>", TypestateError.class, 0);
 		setErrorsCount("<pdf.insecureDefault.InsecureDefaultRSA: void negativeTestCase()>", ConstraintError.class, 1);
@@ -450,37 +450,37 @@ public class BragaCryptoMisusesTest extends AbstractHeadlessTest {
 
 		// positive test case
 		setErrorsCount("<pkc.enc.insecurePadding.InsecurePaddingRSA1: void positiveTestCase()>", TypestateError.class, 0);
-		setErrorsCount("<pkc.enc.insecurePadding.InsecurePaddingRSA1: void positiveTestCase()>", IncompleteOperationError.class, 4);
+		setErrorsCount("<pkc.enc.insecurePadding.InsecurePaddingRSA1: void positiveTestCase()>", IncompleteOperationError.class, 2);
 		setErrorsCount("<pkc.enc.insecurePadding.InsecurePaddingRSA1: void positiveTestCase()>", RequiredPredicateError.class, 0);
 		setErrorsCount("<pkc.enc.insecurePadding.InsecurePaddingRSA1: void positiveTestCase()>", ConstraintError.class, 2);
 		
 		// negative test case
 		setErrorsCount("<pkc.enc.insecurePadding.InsecurePaddingRSA1: void negativeTestCase()>", TypestateError.class, 0);
-		setErrorsCount("<pkc.enc.insecurePadding.InsecurePaddingRSA1: void negativeTestCase()>", IncompleteOperationError.class, 4);
+		setErrorsCount("<pkc.enc.insecurePadding.InsecurePaddingRSA1: void negativeTestCase()>", IncompleteOperationError.class, 2);
 		setErrorsCount("<pkc.enc.insecurePadding.InsecurePaddingRSA1: void negativeTestCase()>", RequiredPredicateError.class, 5);
 		setErrorsCount("<pkc.enc.insecurePadding.InsecurePaddingRSA1: void negativeTestCase()>", ConstraintError.class, 3);
 		
 		// positive test case
 		setErrorsCount("<pkc.enc.insecurePadding.InsecurePaddingRSA2: void positiveTestCase()>", TypestateError.class, 0);
-		setErrorsCount("<pkc.enc.insecurePadding.InsecurePaddingRSA2: void positiveTestCase()>", IncompleteOperationError.class, 4);
+		setErrorsCount("<pkc.enc.insecurePadding.InsecurePaddingRSA2: void positiveTestCase()>", IncompleteOperationError.class, 2);
 		setErrorsCount("<pkc.enc.insecurePadding.InsecurePaddingRSA2: void positiveTestCase()>", RequiredPredicateError.class, 0);
 		setErrorsCount("<pkc.enc.insecurePadding.InsecurePaddingRSA2: void positiveTestCase()>", ConstraintError.class, 0);
 		
 		// negative test case
 		setErrorsCount("<pkc.enc.insecurePadding.InsecurePaddingRSA2: void negativeTestCase()>", TypestateError.class, 0);
-		setErrorsCount("<pkc.enc.insecurePadding.InsecurePaddingRSA2: void negativeTestCase()>", IncompleteOperationError.class, 4);
+		setErrorsCount("<pkc.enc.insecurePadding.InsecurePaddingRSA2: void negativeTestCase()>", IncompleteOperationError.class, 2);
 		setErrorsCount("<pkc.enc.insecurePadding.InsecurePaddingRSA2: void negativeTestCase()>", RequiredPredicateError.class, 5);
 		setErrorsCount("<pkc.enc.insecurePadding.InsecurePaddingRSA2: void negativeTestCase()>", ConstraintError.class, 1);
 		
 		// positive test case
 		setErrorsCount("<pkc.enc.insecurePadding.InsecurePaddingRSA3: void positiveTestCase()>", TypestateError.class, 0);
-		setErrorsCount("<pkc.enc.insecurePadding.InsecurePaddingRSA3: void positiveTestCase()>", IncompleteOperationError.class, 4);
+		setErrorsCount("<pkc.enc.insecurePadding.InsecurePaddingRSA3: void positiveTestCase()>", IncompleteOperationError.class, 2);
 		setErrorsCount("<pkc.enc.insecurePadding.InsecurePaddingRSA3: void positiveTestCase()>", RequiredPredicateError.class, 0);
 		setErrorsCount("<pkc.enc.insecurePadding.InsecurePaddingRSA3: void positiveTestCase()>", ConstraintError.class, 0);
 		
 		// negative test case
 		setErrorsCount("<pkc.enc.insecurePadding.InsecurePaddingRSA3: void negativeTestCase()>", TypestateError.class, 0);
-		setErrorsCount("<pkc.enc.insecurePadding.InsecurePaddingRSA3: void negativeTestCase()>", IncompleteOperationError.class, 4);
+		setErrorsCount("<pkc.enc.insecurePadding.InsecurePaddingRSA3: void negativeTestCase()>", IncompleteOperationError.class, 2);
 		setErrorsCount("<pkc.enc.insecurePadding.InsecurePaddingRSA3: void negativeTestCase()>", RequiredPredicateError.class, 5);
 		setErrorsCount("<pkc.enc.insecurePadding.InsecurePaddingRSA3: void negativeTestCase()>", ConstraintError.class, 1);
 
@@ -562,7 +562,7 @@ public class BragaCryptoMisusesTest extends AbstractHeadlessTest {
 
 		setErrorsCount("<pdf.insecureStreamCipher.ConfusingBlockAndStream: void main(java.lang.String[])>", TypestateError.class, 1);
 		setErrorsCount("<pdf.insecureStreamCipher.ConfusingBlockAndStream: void main(java.lang.String[])>", RequiredPredicateError.class, 7);
-		setErrorsCount("<pdf.insecureStreamCipher.MalealableStreamCipher: void main(java.lang.String[])>", IncompleteOperationError.class, 3);
+		setErrorsCount("<pdf.insecureStreamCipher.MalealableStreamCipher: void main(java.lang.String[])>", IncompleteOperationError.class, 1);
 		setErrorsCount("<pdf.insecureStreamCipher.MalealableStreamCipher: void main(java.lang.String[])>", RequiredPredicateError.class, 5);
 		setErrorsCount("<pdf.insecureStreamCipher.MalealableStreamCipher: void main(java.lang.String[])>", TypestateError.class, 2);
 
@@ -848,7 +848,7 @@ public class BragaCryptoMisusesTest extends AbstractHeadlessTest {
 		setErrorsCount("<cai.undefinedCSP.UndefinedProvider7: void main(java.lang.String[])>", ConstraintError.class, 2);
 		setErrorsCount("<cai.undefinedCSP.UndefinedProvider8: void main(java.lang.String[])>", ConstraintError.class, 1);
 		setErrorsCount("<cai.undefinedCSP.UndefinedProvider8: void main(java.lang.String[])>", RequiredPredicateError.class, 5);
-		setErrorsCount("<cai.undefinedCSP.UndefinedProvider8: void main(java.lang.String[])>", IncompleteOperationError.class, 4);
+		setErrorsCount("<cai.undefinedCSP.UndefinedProvider8: void main(java.lang.String[])>", IncompleteOperationError.class, 2);
 
 		scanner.exec();
 		assertErrors();

--- a/CryptoAnalysis/src/test/java/tests/headless/StaticAnalysisDemoTest.java
+++ b/CryptoAnalysis/src/test/java/tests/headless/StaticAnalysisDemoTest.java
@@ -113,7 +113,7 @@ public class StaticAnalysisDemoTest extends AbstractHeadlessTest {
 		setErrorsCount("<main.Main: void useNoDoFinal()>", ConstraintError.class, 1);
 		//TODO: This is wrong.
 		setErrorsCount("<main.Main: void useDoFinalInLoop()>", TypestateError.class, 0);
-		setErrorsCount("<main.Main: void useDoFinalInLoop()>", IncompleteOperationError.class, 2);
+		setErrorsCount("<main.Main: void useDoFinalInLoop()>", IncompleteOperationError.class, 1);
 		setErrorsCount("<main.Main: void useDoFinalInLoop()>", ConstraintError.class, 1);
 
 		scanner.exec();

--- a/CryptoAnalysis/src/test/resources/testrules/incompleteOperation/Operations.crysl
+++ b/CryptoAnalysis/src/test/resources/testrules/incompleteOperation/Operations.crysl
@@ -1,0 +1,11 @@
+SPEC tests.custom.incompleteoperation.Operations
+
+EVENTS
+    Con: Operations();
+    op1: operation1();
+    op2: operation2();
+    op3: operation3();
+    op4: operation4();
+
+ORDER
+    Con, op1, op2, op3, op4*


### PR DESCRIPTION
IncompleteOperationErrors are reported, if the a dataflow path does not end in an accepting state. However, if there are multiple dataflow paths, multiple IncompleteOperationErrors are reported, although some paths lead to an accepting state. For example, for
```
Cipher c = Cipher.getInstance([...]);
c.init([...]);
if (Math.random() > 0.5) {
    c.doFinal([...]);
}
```
the analysis reports an error at the call to `init` with the info that a call to `doFinal` is missing, and it reports an error at the call to `doFinal` with the info that a call to `doFinal` is missing. The second error is not quite correct because `doFinal` is called on the corresponding dataflow path. Hence, this is a false positive.
This PR adds the logic for reporting the errors only on the correct positions (here at `init`) and adds the information that there is a potential dataflow path, where a call to `doFinal` is missing. This holds also for loops.

Fixes #51 