### PR TITLE
Update: More precise predicate comparing

### DIFF
--- a/CryptoAnalysis/src/main/java/crypto/analysis/AlternativeReqPredicate.java
+++ b/CryptoAnalysis/src/main/java/crypto/analysis/AlternativeReqPredicate.java
@@ -10,20 +10,15 @@ import java.util.stream.Collectors;
 
 public class AlternativeReqPredicate implements ISLConstraint {
 
-	private final Statement stmt;
 	private final List<CrySLPredicate> alternatives;
+	private final Statement stmt;
+	private final int paramIndex;
 
-	public AlternativeReqPredicate(CrySLPredicate alternativeOne, Statement stmt) {
+	public AlternativeReqPredicate(CrySLPredicate alternativeOne, Statement stmt, int paramIndex) {
 		this.alternatives = new ArrayList<>();
 		this.alternatives.add(alternativeOne);
-		this.stmt = stmt;	
-	}
-	
-	public AlternativeReqPredicate(CrySLPredicate alternativeOne, CrySLPredicate alternativeTwo, Statement stmt) {
-		this.alternatives = new ArrayList<>();
-		this.alternatives.add(alternativeOne);
-		this.alternatives.add(alternativeTwo);
 		this.stmt = stmt;
+		this.paramIndex = paramIndex;
 	}
 
 	@Override
@@ -32,6 +27,7 @@ public class AlternativeReqPredicate implements ISLConstraint {
 		int result = 1;
 		result = prime * result + ((alternatives == null) ? 0 : alternatives.hashCode());
 		result = prime * result + ((stmt == null) ? 0 : stmt.hashCode());
+		result = prime * result + paramIndex;
 		return result;
 	}
 
@@ -51,16 +47,24 @@ public class AlternativeReqPredicate implements ISLConstraint {
 			return false;
 		if (stmt == null) {
             return other.stmt == null;
-		} else return stmt.equals(other.stmt);
+		} else if (!stmt.equals(other.stmt)) {
+			return false;
+		}
+
+		return paramIndex == other.paramIndex;
     }
 
 	public Statement getLocation() {
 		return stmt;
 	}
 
+	public int getParamIndex() {
+		return paramIndex;
+	}
+
 	@Override
 	public String toString() {
-		return "misses " + alternatives.stream().map(CrySLPredicate::toString).collect(Collectors.joining(" OR ")) + ((stmt != null) ? " @ " + stmt : "");
+		return alternatives.stream().map(CrySLPredicate::toString).collect(Collectors.joining(" OR ")) + " @ " + stmt + " @ index " + paramIndex;
 	}
 
 	@Override
@@ -81,8 +85,8 @@ public class AlternativeReqPredicate implements ISLConstraint {
 		return alternatives;
 	}
 	
-	public boolean addAlternative(CrySLPredicate newAlt) {
-		return alternatives.add(newAlt);
+	public void addAlternative(CrySLPredicate newAlt) {
+		alternatives.add(newAlt);
 	}
 
 }

--- a/CryptoAnalysis/src/main/java/crypto/analysis/AnalysisSeedWithEnsuredPredicate.java
+++ b/CryptoAnalysis/src/main/java/crypto/analysis/AnalysisSeedWithEnsuredPredicate.java
@@ -18,10 +18,6 @@ public class AnalysisSeedWithEnsuredPredicate extends IAnalysisSeed {
 		super(scanner, statement, fact, results);
 	}
 
-	public static AnalysisSeedWithEnsuredPredicate makeSeedForComparison(CryptoScanner scanner, Statement statement, Val fact) {
-		return new AnalysisSeedWithEnsuredPredicate(scanner, statement, fact, null);
-	}
-
 	@Override
 	public void execute() {
 		if (analysisResults == null) {

--- a/CryptoAnalysis/src/main/java/crypto/analysis/CryptoScanner.java
+++ b/CryptoAnalysis/src/main/java/crypto/analysis/CryptoScanner.java
@@ -20,7 +20,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 
 public abstract class CryptoScanner {
@@ -116,22 +115,6 @@ public abstract class CryptoScanner {
 			}
 		}
 		return seeds;
-	}
-
-	public Optional<AnalysisSeedWithSpecification> getSeedWithSpec(AnalysisSeedWithSpecification seedAtStatement) {
-		if (discoveredSeeds.containsKey(seedAtStatement)) {
-			AnalysisSeedWithSpecification seed = (AnalysisSeedWithSpecification) discoveredSeeds.get(seedAtStatement);
-			return Optional.of(seed);
-		}
-		return Optional.empty();
-	}
-
-	public Optional<AnalysisSeedWithEnsuredPredicate> getSeedWithoutSpec(AnalysisSeedWithEnsuredPredicate seedAtStatement) {
-		if (discoveredSeeds.containsKey(seedAtStatement)) {
-			AnalysisSeedWithEnsuredPredicate seed = (AnalysisSeedWithEnsuredPredicate) discoveredSeeds.get(seedAtStatement);
-			return Optional.of(seed);
-		}
-		return Optional.empty();
 	}
 
 	public PredicateHandler getPredicateHandler() {

--- a/CryptoAnalysis/src/main/java/crypto/analysis/EnsuredCrySLPredicate.java
+++ b/CryptoAnalysis/src/main/java/crypto/analysis/EnsuredCrySLPredicate.java
@@ -11,9 +11,9 @@ public class EnsuredCrySLPredicate {
 	private final CrySLPredicate predicate;
 	private final Multimap<CallSiteWithParamIndex, ExtractedValue> parametersToValues;
 
-	public EnsuredCrySLPredicate(CrySLPredicate predicate, Multimap<CallSiteWithParamIndex, ExtractedValue> parametersToValues2) {
+	public EnsuredCrySLPredicate(CrySLPredicate predicate, Multimap<CallSiteWithParamIndex, ExtractedValue> parametersToValues) {
 		this.predicate = predicate;
-		parametersToValues = parametersToValues2;
+		this.parametersToValues = parametersToValues;
 		
 	}
 	

--- a/CryptoAnalysis/src/main/java/crypto/analysis/IAnalysisSeed.java
+++ b/CryptoAnalysis/src/main/java/crypto/analysis/IAnalysisSeed.java
@@ -6,8 +6,6 @@ import boomerang.scene.Statement;
 import boomerang.scene.Type;
 import boomerang.scene.Val;
 import crypto.analysis.errors.AbstractError;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import typestate.TransitionFunction;
 
 import java.math.BigInteger;
@@ -17,8 +15,6 @@ import java.util.Collection;
 import java.util.HashSet;
 
 public abstract class IAnalysisSeed {
-
-	protected static final Logger LOGGER = LoggerFactory.getLogger(IAnalysisSeed.class);
 
 	protected final CryptoScanner scanner;
 	protected final PredicateHandler predicateHandler;

--- a/CryptoAnalysis/src/main/java/crypto/analysis/RequiredCrySLPredicate.java
+++ b/CryptoAnalysis/src/main/java/crypto/analysis/RequiredCrySLPredicate.java
@@ -10,10 +10,12 @@ public class RequiredCrySLPredicate implements ISLConstraint {
 
 	private final CrySLPredicate predicate;
 	private final Statement statement;
+	private final int paramIndex;
 
-	public RequiredCrySLPredicate(CrySLPredicate predicate, Statement statement) {
+	public RequiredCrySLPredicate(CrySLPredicate predicate, Statement statement, int paramIndex) {
 		this.predicate = predicate;
 		this.statement = statement;
+		this.paramIndex = paramIndex;
 	}
 
 	@Override
@@ -22,6 +24,7 @@ public class RequiredCrySLPredicate implements ISLConstraint {
 		int result = 1;
 		result = prime * result + ((predicate == null) ? 0 : predicate.hashCode());
 		result = prime * result + ((statement == null) ? 0 : statement.hashCode());
+		result = prime * result + paramIndex;
 		return result;
 	}
 
@@ -40,8 +43,13 @@ public class RequiredCrySLPredicate implements ISLConstraint {
 		} else if (!predicate.equals(other.predicate))
 			return false;
 		if (statement == null) {
-            return other.statement == null;
-		} else return statement.equals(other.statement);
+			if (other.statement != null) {
+				return false;
+			}
+		} else if (!statement.equals(other.statement)) {
+			return false;
+		}
+        return paramIndex == other.paramIndex;
     }
 
 	public CrySLPredicate getPred() {
@@ -52,9 +60,13 @@ public class RequiredCrySLPredicate implements ISLConstraint {
 		return statement;
 	}
 
+	public int getParamIndex() {
+		return paramIndex;
+	}
+
 	@Override
 	public String toString() {
-		return "misses " + predicate + " @ " + statement.toString();
+		return predicate + " @ " + statement.toString() + " @ index " + paramIndex;
 	}
 
 	@Override

--- a/CryptoAnalysis/src/main/java/crypto/cryslhandler/StateMachineGraphBuilder.java
+++ b/CryptoAnalysis/src/main/java/crypto/cryslhandler/StateMachineGraphBuilder.java
@@ -190,6 +190,7 @@ public class StateMachineGraphBuilder {
 			// We therefore create a Node and a transition from all startNodes
 			// to this node and a loop from the node to itself.
 			StateNode node = this.result.createNewNode();
+			node.setAccepting(true);
 			Collection<CrySLMethod> label = new HashSet<>(retrieveAllMethodsFromEvents());
 			
 			for (StateNode startNode : startNodes) {

--- a/CryptoAnalysis/src/test/java/test/assertions/ConstraintErrorCountAssertion.java
+++ b/CryptoAnalysis/src/test/java/test/assertions/ConstraintErrorCountAssertion.java
@@ -4,7 +4,7 @@ import test.Assertion;
 
 public class ConstraintErrorCountAssertion implements Assertion {
 
-	private int expectedErrorCounts;
+	private final int expectedErrorCounts;
 	private int actualErrorCounts;
 
 	public ConstraintErrorCountAssertion(int numberOfCounts) {
@@ -23,6 +23,11 @@ public class ConstraintErrorCountAssertion implements Assertion {
 	@Override
 	public boolean isImprecise() {
 		return expectedErrorCounts != actualErrorCounts;
+	}
+
+	@Override
+	public String toString() {
+		return "Expected " + expectedErrorCounts + " constraint errors, but got " + actualErrorCounts;
 	}
 
 }

--- a/CryptoAnalysis/src/test/java/test/assertions/HasEnsuredPredicateAssertion.java
+++ b/CryptoAnalysis/src/test/java/test/assertions/HasEnsuredPredicateAssertion.java
@@ -7,6 +7,7 @@ import crypto.analysis.HiddenPredicate;
 import test.Assertion;
 
 import java.util.Collection;
+import java.util.stream.Collectors;
 
 public class HasEnsuredPredicateAssertion implements Assertion {
 
@@ -52,10 +53,12 @@ public class HasEnsuredPredicateAssertion implements Assertion {
 
 	@Override
 	public String toString() {
+		Collection<String> aliases = val.stream().map(Val::getVariableName).collect(Collectors.toList());
+
 		if (predName == null) {
-			return "Expected a predicate for "+ val +" @ " + stmt;
+			return "Expected a predicate for " + aliases +" @ " + stmt;
 		} else {
-			return "Expected '" + predName + "' ensured on " + val + " @ " + stmt;
+			return "Expected '" + predName + "' ensured on " + aliases + " @ " + stmt;
 		}
 	}
 }

--- a/CryptoAnalysis/src/test/java/test/assertions/NotHasEnsuredPredicateAssertion.java
+++ b/CryptoAnalysis/src/test/java/test/assertions/NotHasEnsuredPredicateAssertion.java
@@ -4,10 +4,10 @@ import boomerang.scene.Statement;
 import boomerang.scene.Val;
 import crypto.analysis.EnsuredCrySLPredicate;
 import crypto.analysis.HiddenPredicate;
-import soot.jimple.Stmt;
 import test.Assertion;
 
 import java.util.Collection;
+import java.util.stream.Collectors;
 
 public class NotHasEnsuredPredicateAssertion implements Assertion {
 
@@ -53,10 +53,12 @@ public class NotHasEnsuredPredicateAssertion implements Assertion {
 
 	@Override
 	public String toString() {
+		Collection<String> aliases = val.stream().map(Val::getVariableName).collect(Collectors.toList());
+
 		if (predName == null) {
-			return "Did not expect a predicate for " + val + " @ " + stmt;
+			return "Did not expect a predicate for " + aliases + " @ " + stmt;
 		} else {
-			return "Did not expect '" + predName + "' ensured on " + val + " @ " + stmt;
+			return "Did not expect '" + predName + "' ensured on " + aliases + " @ " + stmt;
 		}
 	}
 }

--- a/CryptoAnalysis/src/test/java/tests/error/predicate/requiredpredicate/RequiredPredicatesTest.java
+++ b/CryptoAnalysis/src/test/java/tests/error/predicate/requiredpredicate/RequiredPredicatesTest.java
@@ -63,7 +63,6 @@ public class RequiredPredicatesTest extends UsagePatternTestingFramework {
 	// AND
 	
 	// same predicate
-	@Ignore
 	@Test
 	public void pred1onPos1_AND_pred1onPos2() {
 		A pred1onA = new A();
@@ -314,6 +313,7 @@ public class RequiredPredicatesTest extends UsagePatternTestingFramework {
 	// OR
 	
 	// same predicate
+	@Ignore("Requires negated conditional predicates. Alternative predicate have to belong to the same object")
 	@Test
 	public void pred1onPos1_OR_pred1onPos2(){
 		A pred1onA = new A();
@@ -442,6 +442,9 @@ public class RequiredPredicatesTest extends UsagePatternTestingFramework {
 	}
 
 	// multi predicates
+	@Ignore("Can be tested since negated conditions in the REQUIRES section are not supported" +
+			"Alternative predicates on different objects o1 and o2 (p1[o1] || p2[o2] have to be rewritten as" +
+			"!p1[o1] => p2[o2]; and !p2[o2] => p1[o1];")
 	@Test
 	public void pred1onPos1_OR_pred2onPos2() {
 		A pred1onA = new A();
@@ -582,7 +585,7 @@ public class RequiredPredicatesTest extends UsagePatternTestingFramework {
 	}
 	
 	// 3 cases same predicate
-	
+	@Ignore("Negated conditions are not supported see above")
 	@Test
 	public void pred1onPos1_OR_pred1onPos2_OR_pred1onPos3() {
 		A pred1onA = new A();

--- a/CryptoAnalysis/src/test/java/tests/error/predicate/requiredpredicateswiththis/RequiredPredicateWithThisTest.java
+++ b/CryptoAnalysis/src/test/java/tests/error/predicate/requiredpredicateswiththis/RequiredPredicateWithThisTest.java
@@ -51,13 +51,29 @@ public class RequiredPredicateWithThisTest extends UsagePatternTestingFramework 
         Source source = new Source();
         source.causeConstraintError(false);
 
-        TargetWithAlternatives target = source.generateTargetWithAlternatives();
-        target.doNothing("Nothing");
-        Assertions.hasEnsuredPredicate(target, "generatedTargetWithAlternatives");
+        TargetWithAlternatives target1 = source.generateTargetWithAlternatives();
+        target1.doNothing();
+        Assertions.hasEnsuredPredicate(target1, "generatedTargetWithAlternatives");
 
-        UsingTarget usingTarget = new UsingTarget();
-        usingTarget.useTarget(target);
-        Assertions.hasEnsuredPredicate(usingTarget);
+        UsingTarget usingTarget1 = new UsingTarget();
+        usingTarget1.useTarget(target1);
+        Assertions.hasEnsuredPredicate(usingTarget1);
+
+        TargetWithAlternatives target2 = source.generateTargetAlternative1();
+        target2.doNothing();
+        Assertions.hasEnsuredPredicate(target2, "generatedAlternative1");
+
+        UsingTarget usingTarget2 = new UsingTarget();
+        usingTarget2.useTarget(target2);
+        Assertions.hasEnsuredPredicate(usingTarget2);
+
+        TargetWithAlternatives target3 = source.generateTargetAlternative2();
+        target3.doNothing();
+        Assertions.hasEnsuredPredicate(target3, "generatedAlternative2");
+
+        UsingTarget usingTarget3 = new UsingTarget();
+        usingTarget3.useTarget(target3);
+        Assertions.hasEnsuredPredicate(usingTarget3);
 
         Assertions.predicateErrors(0);
     }
@@ -68,15 +84,35 @@ public class RequiredPredicateWithThisTest extends UsagePatternTestingFramework 
         source.causeConstraintError(true);
 
         // No ensured predicate is passed to target -> RequiredPredicateError
-        TargetWithAlternatives target = source.generateTargetWithAlternatives();
-        target.doNothing("Nothing");
-        Assertions.notHasEnsuredPredicate(target);
+        TargetWithAlternatives target1 = source.generateTargetWithAlternatives();
+        target1.doNothing();
+        Assertions.notHasEnsuredPredicate(target1);
 
         // RequiredPredicateError for calling useTarget with insecure target
-        UsingTarget usingTarget = new UsingTarget();
-        usingTarget.useTarget(target);
-        Assertions.notHasEnsuredPredicate(usingTarget);
+        UsingTarget usingTarget1 = new UsingTarget();
+        usingTarget1.useTarget(target1);
+        Assertions.notHasEnsuredPredicate(usingTarget1);
 
-        Assertions.predicateErrors(2);
+        // No ensured predicate is passed to target -> RequiredPredicateError
+        TargetWithAlternatives target2 = source.generateTargetAlternative1();
+        target2.doNothing();
+        Assertions.notHasEnsuredPredicate(target2);
+
+        // RequiredPredicateError for calling useTarget with insecure target
+        UsingTarget usingTarget2 = new UsingTarget();
+        usingTarget2.useTarget(target2);
+        Assertions.notHasEnsuredPredicate(usingTarget2);
+
+        // No ensured predicate is passed to target -> RequiredPredicateError
+        TargetWithAlternatives target3 = source.generateTargetAlternative2();
+        target3.doNothing();
+        Assertions.notHasEnsuredPredicate(target3);
+
+        // RequiredPredicateError for calling useTarget with insecure target
+        UsingTarget usingTarget3 = new UsingTarget();
+        usingTarget3.useTarget(target3);
+        Assertions.notHasEnsuredPredicate(usingTarget3);
+
+        Assertions.predicateErrors(6);
     }
 }

--- a/CryptoAnalysis/src/test/java/tests/error/predicate/requiredpredicateswiththis/Source.java
+++ b/CryptoAnalysis/src/test/java/tests/error/predicate/requiredpredicateswiththis/Source.java
@@ -12,4 +12,12 @@ public class Source {
         return new TargetWithAlternatives();
     }
 
+    public TargetAlternative1 generateTargetAlternative1() {
+        return new TargetAlternative1();
+    }
+
+    public TargetAlternative2 generateTargetAlternative2() {
+        return new TargetAlternative2();
+    }
+
 }

--- a/CryptoAnalysis/src/test/java/tests/error/predicate/requiredpredicateswiththis/TargetAlternative1.java
+++ b/CryptoAnalysis/src/test/java/tests/error/predicate/requiredpredicateswiththis/TargetAlternative1.java
@@ -1,0 +1,4 @@
+package tests.error.predicate.requiredpredicateswiththis;
+
+public class TargetAlternative1 extends TargetWithAlternatives {
+}

--- a/CryptoAnalysis/src/test/java/tests/error/predicate/requiredpredicateswiththis/TargetAlternative2.java
+++ b/CryptoAnalysis/src/test/java/tests/error/predicate/requiredpredicateswiththis/TargetAlternative2.java
@@ -1,0 +1,4 @@
+package tests.error.predicate.requiredpredicateswiththis;
+
+public class TargetAlternative2 extends TargetWithAlternatives {
+}

--- a/CryptoAnalysis/src/test/java/tests/error/predicate/requiredpredicateswiththis/TargetWithAlternatives.java
+++ b/CryptoAnalysis/src/test/java/tests/error/predicate/requiredpredicateswiththis/TargetWithAlternatives.java
@@ -2,5 +2,5 @@ package tests.error.predicate.requiredpredicateswiththis;
 
 public class TargetWithAlternatives {
 
-    public void doNothing(String word) {}
+    public void doNothing() {}
 }

--- a/CryptoAnalysis/src/test/java/tests/headless/BragaCryptoGoodUsesTest.java
+++ b/CryptoAnalysis/src/test/java/tests/headless/BragaCryptoGoodUsesTest.java
@@ -182,7 +182,8 @@ public class BragaCryptoGoodUsesTest extends AbstractHeadlessTest {
 
 		// positive test case
 		setErrorsCount("<example.SecureConfig112bitsRSA_2048x256_1: void positiveTestCase()>", ConstraintError.class, 1);
-		setErrorsCount("<example.SecureConfig112bitsRSA_2048x256_1: void positiveTestCase()>", RequiredPredicateError.class, 0);
+		// This is correct because there are two different 'SHA-256' variables, i.e. the pred is ensured on the first but not on the second one
+		setErrorsCount("<example.SecureConfig112bitsRSA_2048x256_1: void positiveTestCase()>", RequiredPredicateError.class, 1);
 		setErrorsCount("<example.SecureConfig112bitsRSA_2048x256_1: void positiveTestCase()>", TypestateError.class, 1);
 				
 		// negative test case
@@ -202,7 +203,8 @@ public class BragaCryptoGoodUsesTest extends AbstractHeadlessTest {
 		
 		// positive test case
 		setErrorsCount("<example.SecureConfig128bitsRSA_3072x384_1: void positiveTestCase()>", ConstraintError.class, 1);
-		setErrorsCount("<example.SecureConfig128bitsRSA_3072x384_1: void positiveTestCase()>", RequiredPredicateError.class, 0);
+		// This is correct because there are two different 'SHA-256' variables, i.e. the pred is ensured on the first but not on the second one
+		setErrorsCount("<example.SecureConfig128bitsRSA_3072x384_1: void positiveTestCase()>", RequiredPredicateError.class, 1);
 		setErrorsCount("<example.SecureConfig128bitsRSA_3072x384_1: void positiveTestCase()>", TypestateError.class, 1);
 
 		// negative test case
@@ -216,7 +218,8 @@ public class BragaCryptoGoodUsesTest extends AbstractHeadlessTest {
 		
 		// positive test case
 		setErrorsCount("<example.SecureConfig128bitsRSA_4096x512_1: void positiveTestCase()>", ConstraintError.class, 1);
-		setErrorsCount("<example.SecureConfig128bitsRSA_4096x512_1: void positiveTestCase()>", RequiredPredicateError.class, 0);
+		// This is correct because there are two different 'SHA-256' variables, i.e. the pred is ensured on the first but not on the second one
+		setErrorsCount("<example.SecureConfig128bitsRSA_4096x512_1: void positiveTestCase()>", RequiredPredicateError.class, 1);
 		setErrorsCount("<example.SecureConfig128bitsRSA_4096x512_1: void positiveTestCase()>", TypestateError.class, 1);
 		
 		// negative test case
@@ -230,7 +233,8 @@ public class BragaCryptoGoodUsesTest extends AbstractHeadlessTest {
 		
 		// positive test case
 		setErrorsCount("<example.SecureConfig192bitsRSA_7680x384_1: void positiveTestCase()>", ConstraintError.class, 1);
-		setErrorsCount("<example.SecureConfig192bitsRSA_7680x384_1: void positiveTestCase()>", RequiredPredicateError.class, 0);
+		// This is correct because there are two different 'SHA-256' variables, i.e. the pred is ensured on the first but not on the second one
+		setErrorsCount("<example.SecureConfig192bitsRSA_7680x384_1: void positiveTestCase()>", RequiredPredicateError.class, 1);
 		setErrorsCount("<example.SecureConfig192bitsRSA_7680x384_1: void positiveTestCase()>", TypestateError.class, 1);
 		
 		// negative test case
@@ -240,7 +244,8 @@ public class BragaCryptoGoodUsesTest extends AbstractHeadlessTest {
 		
 		// positive test case
 		setErrorsCount("<example.SecureConfig192bitsRSA_7680x512_1: void positiveTestCase()>", ConstraintError.class, 1);
-		setErrorsCount("<example.SecureConfig192bitsRSA_7680x512_1: void positiveTestCase()>", RequiredPredicateError.class, 0);
+		// This is correct because there are two different 'SHA-256' variables, i.e. the pred is ensured on the first but not on the second one
+		setErrorsCount("<example.SecureConfig192bitsRSA_7680x512_1: void positiveTestCase()>", RequiredPredicateError.class, 1);
 		setErrorsCount("<example.SecureConfig192bitsRSA_7680x512_1: void positiveTestCase()>", TypestateError.class, 1);
 				
 		// negative test case
@@ -343,7 +348,8 @@ public class BragaCryptoGoodUsesTest extends AbstractHeadlessTest {
 
 		// positive test case
 		setErrorsCount("<example.OAEP_2048x256_1: void positiveTestCase()>", ConstraintError.class, 1);
-		setErrorsCount("<example.OAEP_2048x256_1: void positiveTestCase()>", RequiredPredicateError.class, 0);
+		// This is correct because there are two different 'SHA-256' variables, i.e. the pred is ensured on the first but not on the second one
+		setErrorsCount("<example.OAEP_2048x256_1: void positiveTestCase()>", RequiredPredicateError.class, 1);
 		setErrorsCount("<example.OAEP_2048x256_1: void positiveTestCase()>", TypestateError.class, 1);
 
 		// negative test case
@@ -363,7 +369,8 @@ public class BragaCryptoGoodUsesTest extends AbstractHeadlessTest {
 		
 		// positive test case
 		setErrorsCount("<example.OAEP_2048x384_1: void positiveTestCase()>", ConstraintError.class, 1);
-		setErrorsCount("<example.OAEP_2048x384_1: void positiveTestCase()>", RequiredPredicateError.class, 0);
+		// This is correct because there are two different 'SHA-256' variables, i.e. the pred is ensured on the first but not on the second one
+		setErrorsCount("<example.OAEP_2048x384_1: void positiveTestCase()>", RequiredPredicateError.class, 1);
 		setErrorsCount("<example.OAEP_2048x384_1: void positiveTestCase()>", TypestateError.class, 1);
 
 		// negative test case
@@ -383,7 +390,8 @@ public class BragaCryptoGoodUsesTest extends AbstractHeadlessTest {
 
 		// positive test case
 		setErrorsCount("<example.OAEP_2048x512_1: void positiveTestCase()>", ConstraintError.class, 1);
-		setErrorsCount("<example.OAEP_2048x512_1: void positiveTestCase()>", RequiredPredicateError.class, 0);
+		// This is correct because there are two different 'SHA-256' variables, i.e. the pred is ensured on the first but not on the second one
+		setErrorsCount("<example.OAEP_2048x512_1: void positiveTestCase()>", RequiredPredicateError.class, 1);
 		setErrorsCount("<example.OAEP_2048x512_1: void positiveTestCase()>", TypestateError.class, 1);
 
 		// negative test case
@@ -779,7 +787,8 @@ public class BragaCryptoGoodUsesTest extends AbstractHeadlessTest {
 
 		// positive test case
 		setErrorsCount("<example.SecureConfig112bitsRSA_2048x256_1: void positiveTestCase()>", ConstraintError.class, 1);
-		setErrorsCount("<example.SecureConfig112bitsRSA_2048x256_1: void positiveTestCase()>", RequiredPredicateError.class, 0);
+		// This is correct because there are two different 'SHA-256' variables, i.e. the pred is ensured on the first but not on the second one
+		setErrorsCount("<example.SecureConfig112bitsRSA_2048x256_1: void positiveTestCase()>", RequiredPredicateError.class, 1);
 		setErrorsCount("<example.SecureConfig112bitsRSA_2048x256_1: void positiveTestCase()>", TypestateError.class, 1);
 		
 		// negative test case
@@ -799,7 +808,8 @@ public class BragaCryptoGoodUsesTest extends AbstractHeadlessTest {
 		
 		// positive test case
 		setErrorsCount("<example.SecureConfig128bitsRSA_3072x384_1: void positiveTestCase()>", ConstraintError.class, 1);
-		setErrorsCount("<example.SecureConfig128bitsRSA_3072x384_1: void positiveTestCase()>", RequiredPredicateError.class, 0);
+		// This is correct because there are two different 'SHA-256' variables, i.e. the pred is ensured on the first but not on the second one
+		setErrorsCount("<example.SecureConfig128bitsRSA_3072x384_1: void positiveTestCase()>", RequiredPredicateError.class, 1);
 		setErrorsCount("<example.SecureConfig128bitsRSA_3072x384_1: void positiveTestCase()>", TypestateError.class, 1);
 
 		// negative test case
@@ -813,7 +823,8 @@ public class BragaCryptoGoodUsesTest extends AbstractHeadlessTest {
 		
 		// positive test case
 		setErrorsCount("<example.SecureConfig128bitsRSA_4096x512_1: void positiveTestCase()>", ConstraintError.class, 1);
-		setErrorsCount("<example.SecureConfig128bitsRSA_4096x512_1: void positiveTestCase()>", RequiredPredicateError.class, 0);
+		// This is correct because there are two different 'SHA-256' variables, i.e. the pred is ensured on the first but not on the second one
+		setErrorsCount("<example.SecureConfig128bitsRSA_4096x512_1: void positiveTestCase()>", RequiredPredicateError.class, 1);
 		setErrorsCount("<example.SecureConfig128bitsRSA_4096x512_1: void positiveTestCase()>", TypestateError.class, 1);
 		
 		// negative test case
@@ -827,7 +838,8 @@ public class BragaCryptoGoodUsesTest extends AbstractHeadlessTest {
 		
 		// positive test case
 		setErrorsCount("<example.SecureConfig192bitsRSA_7680x384_1: void positiveTestCase()>", ConstraintError.class, 1);
-		setErrorsCount("<example.SecureConfig192bitsRSA_7680x384_1: void positiveTestCase()>", RequiredPredicateError.class, 0);
+		// This is correct because there are two different 'SHA-256' variables, i.e. the pred is ensured on the first but not on the second one
+		setErrorsCount("<example.SecureConfig192bitsRSA_7680x384_1: void positiveTestCase()>", RequiredPredicateError.class, 1);
 		setErrorsCount("<example.SecureConfig192bitsRSA_7680x384_1: void positiveTestCase()>", TypestateError.class, 1);
 		
 		// negative test case
@@ -847,7 +859,8 @@ public class BragaCryptoGoodUsesTest extends AbstractHeadlessTest {
 		
 		// positive test case
 		setErrorsCount("<example.SecureConfig192bitsRSA_7680x512_1: void positiveTestCase()>", ConstraintError.class, 1);
-		setErrorsCount("<example.SecureConfig192bitsRSA_7680x512_1: void positiveTestCase()>", RequiredPredicateError.class, 0);
+		// This is correct because there are two different 'SHA-256' variables, i.e. the pred is ensured on the first but not on the second one
+		setErrorsCount("<example.SecureConfig192bitsRSA_7680x512_1: void positiveTestCase()>", RequiredPredicateError.class, 1);
 		setErrorsCount("<example.SecureConfig192bitsRSA_7680x512_1: void positiveTestCase()>", TypestateError.class, 1);
 		
 		// negative test case

--- a/CryptoAnalysis/src/test/java/tests/headless/BragaCryptoMisusesTest.java
+++ b/CryptoAnalysis/src/test/java/tests/headless/BragaCryptoMisusesTest.java
@@ -894,7 +894,7 @@ public class BragaCryptoMisusesTest extends AbstractHeadlessTest {
 		// positive test case
 		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_384x160_1: void positiveTestCase()>", TypestateError.class, 1);
 		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_384x160_1: void positiveTestCase()>", ConstraintError.class, 2);
-		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_384x160_1: void positiveTestCase()>", RequiredPredicateError.class, 5);
+		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_384x160_1: void positiveTestCase()>", RequiredPredicateError.class, 6);
 		
 		// negative test case
 		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_384x160_1: void negativeTestCase()>", TypestateError.class, 1);
@@ -904,7 +904,7 @@ public class BragaCryptoMisusesTest extends AbstractHeadlessTest {
 		// positive test case
 		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_512x160_1: void positiveTestCase()>", TypestateError.class, 1);
 		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_512x160_1: void positiveTestCase()>", ConstraintError.class, 2);
-		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_512x160_1: void positiveTestCase()>", RequiredPredicateError.class, 5);
+		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_512x160_1: void positiveTestCase()>", RequiredPredicateError.class, 6);
 
 		// negative test case
 		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_512x160_1: void negativeTestCase()>", TypestateError.class, 1);
@@ -914,7 +914,7 @@ public class BragaCryptoMisusesTest extends AbstractHeadlessTest {
 		// positive test case
 		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_768x160_1: void positiveTestCase()>", TypestateError.class, 1);
 		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_768x160_1: void positiveTestCase()>", ConstraintError.class, 2);
-		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_768x160_1: void positiveTestCase()>", RequiredPredicateError.class, 5);
+		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_768x160_1: void positiveTestCase()>", RequiredPredicateError.class, 6);
 
 		// negative test case
 		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_768x160_1: void negativeTestCase()>", TypestateError.class, 1);
@@ -924,7 +924,7 @@ public class BragaCryptoMisusesTest extends AbstractHeadlessTest {
 		// positive test case
 		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_768x256_1: void positiveTestCase()>", TypestateError.class, 1);
 		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_768x256_1: void positiveTestCase()>", ConstraintError.class, 2);
-		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_768x256_1: void positiveTestCase()>", RequiredPredicateError.class, 5);
+		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_768x256_1: void positiveTestCase()>", RequiredPredicateError.class, 6);
 
 		// negative test case
 		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_768x256_1: void negativeTestCase()>", TypestateError.class, 1);
@@ -934,7 +934,7 @@ public class BragaCryptoMisusesTest extends AbstractHeadlessTest {
 		// positive test case
 		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_1024x160_1: void positiveTestCase()>", TypestateError.class, 1);
 		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_1024x160_1: void positiveTestCase()>", ConstraintError.class, 2);
-		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_1024x160_1: void positiveTestCase()>", RequiredPredicateError.class, 5);
+		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_1024x160_1: void positiveTestCase()>", RequiredPredicateError.class, 6);
 		
 		// negative test case
 		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_1024x160_1: void negativeTestCase()>", TypestateError.class, 1);
@@ -944,7 +944,7 @@ public class BragaCryptoMisusesTest extends AbstractHeadlessTest {
 		// positive test case
 		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_1024x256_1: void positiveTestCase()>", TypestateError.class, 1);
 		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_1024x256_1: void positiveTestCase()>", ConstraintError.class, 2);
-		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_1024x256_1: void positiveTestCase()>", RequiredPredicateError.class, 5);
+		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_1024x256_1: void positiveTestCase()>", RequiredPredicateError.class, 6);
 		
 		// negative test case
 		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_1024x256_1: void negativeTestCase()>", TypestateError.class, 1);
@@ -954,7 +954,7 @@ public class BragaCryptoMisusesTest extends AbstractHeadlessTest {
 		// positive test case
 		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_1024x384_1: void positiveTestCase()>", TypestateError.class, 1);
 		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_1024x384_1: void positiveTestCase()>", ConstraintError.class, 2);
-		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_1024x384_1: void positiveTestCase()>", RequiredPredicateError.class, 5);
+		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_1024x384_1: void positiveTestCase()>", RequiredPredicateError.class, 6);
 
 		// negative test case
 		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_1024x384_1: void negativeTestCase()>", TypestateError.class, 1);
@@ -964,7 +964,7 @@ public class BragaCryptoMisusesTest extends AbstractHeadlessTest {
 		// positive test case
 		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_2048x160_1: void positiveTestCase()>", TypestateError.class, 1);
 		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_2048x160_1: void positiveTestCase()>", ConstraintError.class, 2);
-		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_2048x160_1: void positiveTestCase()>", RequiredPredicateError.class, 5);
+		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_2048x160_1: void positiveTestCase()>", RequiredPredicateError.class, 6);
 
 		// negative test case
 		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_2048x160_1: void negativeTestCase()>", TypestateError.class, 1);
@@ -974,7 +974,7 @@ public class BragaCryptoMisusesTest extends AbstractHeadlessTest {
 		// positive test case
 		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_3072x160_1: void positiveTestCase()>", TypestateError.class, 1);
 		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_3072x160_1: void positiveTestCase()>", ConstraintError.class, 1);
-		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_3072x160_1: void positiveTestCase()>", RequiredPredicateError.class, 0);
+		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_3072x160_1: void positiveTestCase()>", RequiredPredicateError.class, 1);
 
 		// negative test case
 		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_3072x160_1: void negativeTestCase()>", TypestateError.class, 1);
@@ -984,7 +984,7 @@ public class BragaCryptoMisusesTest extends AbstractHeadlessTest {
 		// positive test case
 		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_4096x160_1: void positiveTestCase()>", TypestateError.class, 1);
 		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_4096x160_1: void positiveTestCase()>", ConstraintError.class, 1);
-		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_4096x160_1: void positiveTestCase()>", RequiredPredicateError.class, 0);
+		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_4096x160_1: void positiveTestCase()>", RequiredPredicateError.class, 1);
 
 		// negative test case
 		setErrorsCount("<pkc.enc.weakConfigsRSA.ImproperConfigRSA_4096x160_1: void negativeTestCase()>", TypestateError.class, 1);

--- a/CryptoAnalysis/src/test/resources/testrules/requiredPredicateWithThis/Source.crysl
+++ b/CryptoAnalysis/src/test/resources/testrules/requiredPredicateWithThis/Source.crysl
@@ -4,17 +4,21 @@ OBJECTS
     boolean constraintError;
     tests.error.predicate.requiredpredicateswiththis.SimpleTarget target1;
     tests.error.predicate.requiredpredicateswiththis.TargetWithAlternatives target2;
+    tests.error.predicate.requiredpredicateswiththis.TargetAlternative1 target3;
+    tests.error.predicate.requiredpredicateswiththis.TargetAlternative2 target4;
 
 EVENTS
     Con: Source();
     causeError: causeConstraintError(constraintError);
     passPred1: target1 = generateTarget();
     passPred2: target2 = generateTargetWithAlternatives();
+    passPred3: target3 = generateTargetAlternative1();
+    passPred4: target4 = generateTargetAlternative2();
 
-    passPred := passPred1 | passPred2;
+    passPred := passPred1 | passPred2 | passPred3 | passPred4;
 
 ORDER
-    Con, causeError, passPred
+    Con, causeError, passPred*
 
 CONSTRAINTS
     constraintError in {false};
@@ -22,3 +26,5 @@ CONSTRAINTS
 ENSURES
     generatedTarget[target1];
     generatedTargetWithAlternatives[target2];
+    generatedAlternative1[target3];
+    generatedAlternative2[target4];

--- a/CryptoAnalysis/src/test/resources/testrules/requiredPredicateWithThis/TargetAlternative1.crysl
+++ b/CryptoAnalysis/src/test/resources/testrules/requiredPredicateWithThis/TargetAlternative1.crysl
@@ -1,0 +1,4 @@
+SPEC tests.error.predicate.requiredpredicateswiththis.TargetAlternative1
+
+REQUIRES
+    generatedAlternative1[this];

--- a/CryptoAnalysis/src/test/resources/testrules/requiredPredicateWithThis/TargetAlternative2.crysl
+++ b/CryptoAnalysis/src/test/resources/testrules/requiredPredicateWithThis/TargetAlternative2.crysl
@@ -1,0 +1,4 @@
+SPEC tests.error.predicate.requiredpredicateswiththis.TargetAlternative2
+
+REQUIRES
+    generatedAlternative2[this];

--- a/CryptoAnalysis/src/test/resources/testrules/requiredPredicateWithThis/TargetWithAlternatives.crysl
+++ b/CryptoAnalysis/src/test/resources/testrules/requiredPredicateWithThis/TargetWithAlternatives.crysl
@@ -1,14 +1,11 @@
 SPEC tests.error.predicate.requiredpredicateswiththis.TargetWithAlternatives
 
-OBJECTS
-    java.lang.String word;
-
 EVENTS
     Con: TargetWithAlternatives();
-    dN: doNothing(word);
+    dN: doNothing();
 
 ORDER
     Con, dN*
 
 REQUIRES
-    generatedTargetWithAlternatives[this] || generatedWord[word];
+    generatedTargetWithAlternatives[this] || generatedAlternative1[this] || generatedAlternative2[this];

--- a/CryptoAnalysis/src/test/resources/testrules/requiredPredicateWithThis/UsingTarget.crysl
+++ b/CryptoAnalysis/src/test/resources/testrules/requiredPredicateWithThis/UsingTarget.crysl
@@ -16,7 +16,7 @@ ORDER
 
 REQUIRES
     generatedTarget[target1];
-    generatedTargetWithAlternatives[target2];
+    generatedTargetWithAlternatives[target2] || generatedAlternative1[target2] || generatedAlternative2[target2];
 
 ENSURES
     usedTarget[this];

--- a/CryptoAnalysis/src/test/resources/testrules/requiredPredicates/Requires.crysl
+++ b/CryptoAnalysis/src/test/resources/testrules/requiredPredicates/Requires.crysl
@@ -191,7 +191,11 @@ REQUIRES
 	pred1[p1inO2] || !pred1[p2inO2];
 	!pred1[p1inO3] || pred1[p2inO3];
 	!pred1[p1inO4] || !pred1[p2inO4];
-	pred1[p1inO5] || pred2[p2inO5];
+
+	// pred1[p1inO5] or pred2[p2inO5];
+	// !pred1[p1inO5] => pred2[p2inO5];   negated condition not supported
+	// !pred2[p2inO5] => pred1[p1inO5];   negated condition not supported
+
 	pred1[p1inO6] || !pred2[p2inO6];
 	!pred1[p1inO7] || pred2[p2inO7];
 	!pred1[p1inO8] || !pred2[p2inO8];


### PR DESCRIPTION
Currently, if a predicate is ensured, it is just ensured for specific statements. Although this works with current rules, it is not precise if statements require the same predicate for multiple objects. For example, consider the method `superRandom(SecureRandom sr1, SecureRandom sr2)` and the `REQUIRES` section with `randomized[sr1]` and `randomized[sr2]`. In that case, CryptoAnalysis does not report an error if only one `randomized` predicate is ensured because as soon as one `randomized` is ensured, it holds for the complete statement, that is, there is no distinction between the parameters, and it assumes that the predicate counts for `sr1` and `sr2` despite only one object ensuring `randomized`.

This PR adds the parameter indices to the required predicates to be able to distinguish such cases. More precisely, instead of just storing "requires `randomized` @ superRandom", it stores "requires `randomized` @ superRandom @ index 1" and "requires `randomized` @ superRandom @ index 2". This way, CryptoAnalysis can distinguish the objects.

Obsoletes #375 