### PR TITLE
Bring back analysis statistics to reports

### DIFF
--- a/CryptoAnalysis/src/main/java/crypto/constraints/ConstraintSolver.java
+++ b/CryptoAnalysis/src/main/java/crypto/constraints/ConstraintSolver.java
@@ -6,7 +6,7 @@ import boomerang.scene.DataFlowScope;
 import boomerang.scene.Statement;
 import com.google.common.collect.Lists;
 import crypto.analysis.AlternativeReqPredicate;
-import crypto.analysis.AnalysisReporter;
+import crypto.listener.AnalysisReporter;
 import crypto.analysis.AnalysisSeedWithSpecification;
 import crypto.analysis.RequiredCrySLPredicate;
 import crypto.analysis.errors.AbstractError;

--- a/CryptoAnalysis/src/main/java/crypto/definition/ExtractParameterDefinition.java
+++ b/CryptoAnalysis/src/main/java/crypto/definition/ExtractParameterDefinition.java
@@ -3,7 +3,7 @@ package crypto.definition;
 import boomerang.scene.CallGraph;
 import boomerang.scene.DataFlowScope;
 import boomerang.scene.Statement;
-import crypto.analysis.AnalysisReporter;
+import crypto.listener.AnalysisReporter;
 import crypto.rules.CrySLRule;
 
 import java.util.Collection;

--- a/CryptoAnalysis/src/main/java/crypto/listener/AnalysisPrinter.java
+++ b/CryptoAnalysis/src/main/java/crypto/listener/AnalysisPrinter.java
@@ -1,10 +1,12 @@
-package crypto.analysis;
+package crypto.listener;
 
+import boomerang.scene.CallGraph;
 import boomerang.scene.Statement;
 import boomerang.scene.Val;
+import com.google.common.base.Stopwatch;
+import crypto.analysis.IAnalysisSeed;
 import crypto.analysis.errors.AbstractError;
 import crypto.extractparameter.ExtractParameterQuery;
-import crypto.listener.IAnalysisListener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -14,24 +16,75 @@ public class AnalysisPrinter implements IAnalysisListener {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AnalysisPrinter.class);
 
+    private final AnalysisStatistics statistics = new AnalysisStatistics();
+
+    private final Stopwatch analysisWatch = Stopwatch.createUnstarted();
+    private final Stopwatch callGraphWatch = Stopwatch.createUnstarted();
+    private final Stopwatch typestateWatch = Stopwatch.createUnstarted();
+
+    public AnalysisStatistics getStatistics() {
+        return statistics;
+    }
+
     @Override
     public void beforeAnalysis() {
-        LOGGER.debug("Starting Scan...");
+        LOGGER.info("Starting analysis...");
+
+        if (!analysisWatch.isRunning()) {
+            analysisWatch.start();
+        }
     }
 
     @Override
     public void afterAnalysis() {
-        LOGGER.debug("Finished Scan");
+        if (analysisWatch.isRunning()) {
+            analysisWatch.stop();
+        }
+
+        statistics.setAnalysisTime(analysisWatch.toString());
+
+        LOGGER.info("Finished Analysis in {}", analysisWatch);
+    }
+
+    @Override
+    public void beforeCallGraphConstruction() {
+        LOGGER.info("Constructing Call Graph...");
+
+        if (!callGraphWatch.isRunning()) {
+            callGraphWatch.start();
+        }
+    }
+
+    @Override
+    public void afterCallGraphConstruction(CallGraph callGraph) {
+        if (callGraphWatch.isRunning()) {
+            callGraphWatch.stop();
+        }
+
+        statistics.setCallGraphTime(callGraphWatch.toString());
+        statistics.setCallGraph(callGraph);
+
+        LOGGER.info("Constructed Call Graph in {}", callGraphWatch);
     }
 
     @Override
     public void beforeTypestateAnalysis() {
-        LOGGER.debug("Starting Typestate Analysis");
+        LOGGER.info("Starting Typestate Analysis...");
+
+        if (!typestateWatch.isRunning()) {
+            typestateWatch.start();
+        }
     }
 
     @Override
     public void afterTypestateAnalysis() {
-        LOGGER.debug("Typestate Analysis finished");
+        if (typestateWatch.isRunning()) {
+            typestateWatch.stop();
+        }
+
+        statistics.setTypestateTime(typestateWatch.toString());
+
+        LOGGER.info("Finished Typestate Analysis in {}", typestateWatch);
     }
 
     @Override

--- a/CryptoAnalysis/src/main/java/crypto/listener/AnalysisReporter.java
+++ b/CryptoAnalysis/src/main/java/crypto/listener/AnalysisReporter.java
@@ -1,10 +1,13 @@
-package crypto.analysis;
+package crypto.listener;
 
 import boomerang.results.BackwardBoomerangResults;
 import boomerang.results.ForwardBoomerangResults;
+import boomerang.scene.CallGraph;
 import boomerang.scene.Statement;
 import boomerang.scene.Val;
 import com.google.common.collect.Table;
+import crypto.analysis.EnsuredCrySLPredicate;
+import crypto.analysis.IAnalysisSeed;
 import crypto.analysis.errors.AbstractError;
 import crypto.analysis.errors.CallToError;
 import crypto.analysis.errors.ConstraintError;
@@ -65,6 +68,22 @@ public class AnalysisReporter {
     public void afterAnalysis() {
         for (IAnalysisListener analysisListener : analysisListeners) {
             analysisListener.afterAnalysis();
+        }
+    }
+
+    public void beforeCallGraphConstruction() {
+        for (IAnalysisListener analysisListener : analysisListeners) {
+            analysisListener.beforeCallGraphConstruction();
+        }
+    }
+
+    public void afterCallGraphConstruction(CallGraph callGraph) {
+        for (IAnalysisListener analysisListener : analysisListeners) {
+            analysisListener.afterCallGraphConstruction(callGraph);
+        }
+
+        for (IResultsListener resultsListener : resultsListeners) {
+            resultsListener.constructedCallGraph(callGraph);
         }
     }
 

--- a/CryptoAnalysis/src/main/java/crypto/listener/AnalysisStatistics.java
+++ b/CryptoAnalysis/src/main/java/crypto/listener/AnalysisStatistics.java
@@ -1,0 +1,54 @@
+package crypto.listener;
+
+import boomerang.scene.CallGraph;
+
+public class AnalysisStatistics {
+
+    private String analysisTime;
+    private String callGraphTime;
+    private String typestateTime;
+    private CallGraph callGraph;
+
+    public AnalysisStatistics() {}
+
+    public String getAnalysisTime() {
+        return analysisTime;
+    }
+
+    public void setAnalysisTime(String analysisTime) {
+        this.analysisTime = analysisTime;
+    }
+
+    public String getCallGraphTime() {
+        return callGraphTime;
+    }
+
+    public void setCallGraphTime(String callGraphTime) {
+        this.callGraphTime = callGraphTime;
+    }
+
+    public String getTypestateTime() {
+        return typestateTime;
+    }
+
+    public void setTypestateTime(String typestateTime) {
+        this.typestateTime = typestateTime;
+    }
+
+    public void setCallGraph(CallGraph callGraph) {
+        this.callGraph = callGraph;
+    }
+
+    public int getReachableMethods() {
+        return callGraph.getReachableMethods().size();
+    }
+
+    public int getEdges() {
+        return callGraph.size();
+    }
+
+    public int getEntryPoints() {
+        return callGraph.getEntryPoints().size();
+    }
+
+}

--- a/CryptoAnalysis/src/main/java/crypto/listener/ErrorCollector.java
+++ b/CryptoAnalysis/src/main/java/crypto/listener/ErrorCollector.java
@@ -1,4 +1,4 @@
-package crypto.analysis;
+package crypto.listener;
 
 import boomerang.scene.Method;
 import boomerang.scene.WrappedClass;

--- a/CryptoAnalysis/src/main/java/crypto/listener/IAnalysisListener.java
+++ b/CryptoAnalysis/src/main/java/crypto/listener/IAnalysisListener.java
@@ -1,5 +1,6 @@
 package crypto.listener;
 
+import boomerang.scene.CallGraph;
 import boomerang.scene.Statement;
 import boomerang.scene.Val;
 import crypto.analysis.IAnalysisSeed;
@@ -17,6 +18,10 @@ public interface IAnalysisListener {
     void beforeTypestateAnalysis();
 
     void afterTypestateAnalysis();
+
+    void beforeCallGraphConstruction();
+
+    void afterCallGraphConstruction(CallGraph callGraph);
 
     void beforeTriggeringBoomerangQuery(ExtractParameterQuery query);
 

--- a/CryptoAnalysis/src/main/java/crypto/listener/IResultsListener.java
+++ b/CryptoAnalysis/src/main/java/crypto/listener/IResultsListener.java
@@ -2,6 +2,7 @@ package crypto.listener;
 
 import boomerang.results.BackwardBoomerangResults;
 import boomerang.results.ForwardBoomerangResults;
+import boomerang.scene.CallGraph;
 import boomerang.scene.Statement;
 import boomerang.scene.Val;
 import com.google.common.collect.Multimap;
@@ -20,6 +21,8 @@ import java.util.Collection;
 import java.util.Set;
 
 public interface IResultsListener {
+
+    void constructedCallGraph(CallGraph callGraph);
 
     void typestateAnalysisResults(IAnalysisSeed seed, ForwardBoomerangResults<TransitionFunction> results);
 

--- a/CryptoAnalysis/src/main/java/crypto/reporting/CSVReporter.java
+++ b/CryptoAnalysis/src/main/java/crypto/reporting/CSVReporter.java
@@ -6,6 +6,7 @@ import com.google.common.base.Joiner;
 import com.google.common.collect.Table;
 import crypto.analysis.IAnalysisSeed;
 import crypto.analysis.errors.AbstractError;
+import crypto.listener.AnalysisStatistics;
 import crypto.rules.CrySLRule;
 import crypto.utils.ErrorUtils;
 
@@ -34,7 +35,7 @@ public class CSVReporter extends Reporter {
     }
 
     @Override
-    public void createAnalysisReport(Collection<IAnalysisSeed> seeds, Table<WrappedClass, Method, Set<AbstractError>> errorCollection) {
+    public void createAnalysisReport(Collection<IAnalysisSeed> seeds, Table<WrappedClass, Method, Set<AbstractError>> errorCollection, AnalysisStatistics statistics) {
         int idCount = 0;
         List<String> lineContents = new ArrayList<>();
 

--- a/CryptoAnalysis/src/main/java/crypto/reporting/CSVSummaryReporter.java
+++ b/CryptoAnalysis/src/main/java/crypto/reporting/CSVSummaryReporter.java
@@ -19,6 +19,7 @@ import crypto.analysis.errors.PredicateContradictionError;
 import crypto.analysis.errors.RequiredPredicateError;
 import crypto.analysis.errors.TypestateError;
 import crypto.analysis.errors.UncaughtExceptionError;
+import crypto.listener.AnalysisStatistics;
 import crypto.rules.CrySLRule;
 import crypto.utils.ErrorUtils;
 
@@ -43,7 +44,7 @@ public class CSVSummaryReporter extends Reporter {
     }
 
     @Override
-    public void createAnalysisReport(Collection<IAnalysisSeed> seeds, Table<WrappedClass, Method, Set<AbstractError>> errorCollection) {
+    public void createAnalysisReport(Collection<IAnalysisSeed> seeds, Table<WrappedClass, Method, Set<AbstractError>> errorCollection, AnalysisStatistics statistics) {
         Map<String, Integer> errorCounts = ErrorUtils.getErrorCounts(errorCollection);
 
         String fileName = outputFile.getAbsolutePath() + File.separator + REPORT_NAME + "-Summary" + FILE_ENDING;

--- a/CryptoAnalysis/src/main/java/crypto/reporting/CommandLineReporter.java
+++ b/CryptoAnalysis/src/main/java/crypto/reporting/CommandLineReporter.java
@@ -5,6 +5,7 @@ import boomerang.scene.WrappedClass;
 import com.google.common.collect.Table;
 import crypto.analysis.IAnalysisSeed;
 import crypto.analysis.errors.AbstractError;
+import crypto.listener.AnalysisStatistics;
 import crypto.rules.CrySLRule;
 
 import java.util.Collection;
@@ -17,8 +18,8 @@ public class CommandLineReporter extends Reporter {
     }
 
     @Override
-    public void createAnalysisReport(Collection<IAnalysisSeed> seeds, Table<WrappedClass, Method, Set<AbstractError>> errorCollection) {
-        String report = ReportGenerator.generateReport(seeds, ruleset, errorCollection);
+    public void createAnalysisReport(Collection<IAnalysisSeed> seeds, Table<WrappedClass, Method, Set<AbstractError>> errorCollection, AnalysisStatistics statistics) {
+        String report = ReportGenerator.generateReport(seeds, ruleset, errorCollection, statistics);
         System.out.println(report);
     }
 }

--- a/CryptoAnalysis/src/main/java/crypto/reporting/GitHubAnnotationReporter.java
+++ b/CryptoAnalysis/src/main/java/crypto/reporting/GitHubAnnotationReporter.java
@@ -5,6 +5,7 @@ import boomerang.scene.WrappedClass;
 import com.google.common.collect.Table;
 import crypto.analysis.IAnalysisSeed;
 import crypto.analysis.errors.AbstractError;
+import crypto.listener.AnalysisStatistics;
 import crypto.rules.CrySLRule;
 import crypto.utils.ErrorUtils;
 
@@ -50,7 +51,7 @@ public class GitHubAnnotationReporter extends CommandLineReporter {
     }
 
     @Override
-    public void createAnalysisReport(Collection<IAnalysisSeed> seeds, Table<WrappedClass, Method, Set<AbstractError>> errorCollection) {
+    public void createAnalysisReport(Collection<IAnalysisSeed> seeds, Table<WrappedClass, Method, Set<AbstractError>> errorCollection, AnalysisStatistics statistics) {
         System.out.println("::group::Annotations");
 
         // report errors on individual lines
@@ -104,6 +105,16 @@ public class GitHubAnnotationReporter extends CommandLineReporter {
         int errorCount = errorCounts.values().stream().reduce(0, Integer::sum);
         summary.append(String.format("Number of violations: %s\n", errorCount));
 
+        if (statistics != null) {
+            summary.append("\n");
+            summary.append("Total Analysis Time: ").append(statistics.getAnalysisTime()).append("\n");
+            summary.append("Call Graph Construction Time: ").append(statistics.getCallGraphTime()).append("\n");
+            summary.append("Typestate Analysis Time: ").append(statistics.getTypestateTime()).append("\n");
+            summary.append("Reachable Methods: ").append(statistics.getReachableMethods()).append("\n");
+            summary.append("Edges in Call Graph: ").append(statistics.getEdges()).append("\n");
+            summary.append("Entry Points: ").append(statistics.getEntryPoints()).append("\n");
+        }
+
         // GitHub only displays 10 error annotations and silently drops the rest.
         // https://github.com/orgs/community/discussions/26680
         // https://github.com/orgs/community/discussions/68471
@@ -118,7 +129,7 @@ public class GitHubAnnotationReporter extends CommandLineReporter {
 
         System.out.println("::endgroup::");
 
-        super.createAnalysisReport(seeds, errorCollection);
+        super.createAnalysisReport(seeds, errorCollection, statistics);
 
         if (errorCount != 0) {
             System.exit(1);

--- a/CryptoAnalysis/src/main/java/crypto/reporting/ReportGenerator.java
+++ b/CryptoAnalysis/src/main/java/crypto/reporting/ReportGenerator.java
@@ -5,6 +5,7 @@ import boomerang.scene.WrappedClass;
 import com.google.common.collect.Table;
 import crypto.analysis.IAnalysisSeed;
 import crypto.analysis.errors.AbstractError;
+import crypto.listener.AnalysisStatistics;
 import crypto.rules.CrySLRule;
 import crypto.utils.ErrorUtils;
 
@@ -21,9 +22,10 @@ public class ReportGenerator {
      * @param seeds the analyzed seeds
      * @param ruleset the ruleset used in the analysis
      * @param errorCollection the table containing the errors
+     * @param statistics the statistics from the analysis
      * @return the formatted report for the {@link CommandLineReporter} and {@link TXTReporter}
      */
-    public static String generateReport(Collection<IAnalysisSeed> seeds, Collection<CrySLRule> ruleset, Table<WrappedClass, Method, Set<AbstractError>> errorCollection) {
+    public static String generateReport(Collection<IAnalysisSeed> seeds, Collection<CrySLRule> ruleset, Table<WrappedClass, Method, Set<AbstractError>> errorCollection, AnalysisStatistics statistics) {
         StringBuilder report = new StringBuilder();
 
         report.append("Ruleset:\n");
@@ -73,6 +75,16 @@ public class ReportGenerator {
             for (Map.Entry<String, Integer> entry : errorCounts.entrySet()) {
                 report.append("\t").append(entry.getKey()).append(": ").append(entry.getValue()).append("\n");
             }
+        }
+
+        if (statistics != null) {
+            report.append("\n");
+            report.append("\tTotal Analysis Time: ").append(statistics.getAnalysisTime()).append("\n");
+            report.append("\tCall Graph Construction Time: ").append(statistics.getCallGraphTime()).append("\n");
+            report.append("\tTypestate Analysis Time: ").append(statistics.getTypestateTime()).append("\n");
+            report.append("\tReachable Methods: ").append(statistics.getReachableMethods()).append("\n");
+            report.append("\tEdges in Call Graph: ").append(statistics.getEdges()).append("\n");
+            report.append("\tEntry Points: ").append(statistics.getEntryPoints()).append("\n");
         }
 
         return report.toString();

--- a/CryptoAnalysis/src/main/java/crypto/reporting/Reporter.java
+++ b/CryptoAnalysis/src/main/java/crypto/reporting/Reporter.java
@@ -5,6 +5,7 @@ import boomerang.scene.WrappedClass;
 import com.google.common.collect.Table;
 import crypto.analysis.IAnalysisSeed;
 import crypto.analysis.errors.AbstractError;
+import crypto.listener.AnalysisStatistics;
 import crypto.rules.CrySLRule;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -47,5 +48,5 @@ public abstract class Reporter {
         this.ruleset = ruleset;
     }
 
-    public abstract void createAnalysisReport(Collection<IAnalysisSeed> seeds, Table<WrappedClass, Method, Set<AbstractError>> errorCollection);
+    public abstract void createAnalysisReport(Collection<IAnalysisSeed> seeds, Table<WrappedClass, Method, Set<AbstractError>> errorCollection, AnalysisStatistics statistics);
 }

--- a/CryptoAnalysis/src/main/java/crypto/reporting/SARIFReporter.java
+++ b/CryptoAnalysis/src/main/java/crypto/reporting/SARIFReporter.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.ObjectWriter;
 import com.google.common.collect.Table;
 import crypto.analysis.IAnalysisSeed;
 import crypto.analysis.errors.AbstractError;
+import crypto.listener.AnalysisStatistics;
 import crypto.rules.CrySLRule;
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -60,7 +61,7 @@ public class SARIFReporter extends Reporter {
     }
 
     @Override
-    public void createAnalysisReport(Collection<IAnalysisSeed> seeds, Table<WrappedClass, Method, Set<AbstractError>> errorCollection) {
+    public void createAnalysisReport(Collection<IAnalysisSeed> seeds, Table<WrappedClass, Method, Set<AbstractError>> errorCollection, AnalysisStatistics statistics) {
         for (WrappedClass wrappedClass : errorCollection.rowKeySet()) {
             addFile(wrappedClass);
 

--- a/CryptoAnalysis/src/main/java/crypto/reporting/TXTReporter.java
+++ b/CryptoAnalysis/src/main/java/crypto/reporting/TXTReporter.java
@@ -5,6 +5,7 @@ import boomerang.scene.WrappedClass;
 import com.google.common.collect.Table;
 import crypto.analysis.IAnalysisSeed;
 import crypto.analysis.errors.AbstractError;
+import crypto.listener.AnalysisStatistics;
 import crypto.rules.CrySLRule;
 
 import java.io.File;
@@ -22,8 +23,8 @@ public class TXTReporter extends Reporter {
     }
 
     @Override
-    public void createAnalysisReport(Collection<IAnalysisSeed> seeds, Table<WrappedClass, Method, Set<AbstractError>> errorCollection) {
-        String report = ReportGenerator.generateReport(seeds, ruleset, errorCollection);
+    public void createAnalysisReport(Collection<IAnalysisSeed> seeds, Table<WrappedClass, Method, Set<AbstractError>> errorCollection, AnalysisStatistics statistics) {
+        String report = ReportGenerator.generateReport(seeds, ruleset, errorCollection, statistics);
 
         String fileName = outputFile.getAbsolutePath() + File.separator + REPORT_NAME + FILE_ENDING;
         try (FileWriter writer = new FileWriter(fileName)) {

--- a/CryptoAnalysis/src/test/java/test/UsagePatternResultsListener.java
+++ b/CryptoAnalysis/src/test/java/test/UsagePatternResultsListener.java
@@ -2,6 +2,7 @@ package test;
 
 import boomerang.results.BackwardBoomerangResults;
 import boomerang.results.ForwardBoomerangResults;
+import boomerang.scene.CallGraph;
 import boomerang.scene.ControlFlowGraph;
 import boomerang.scene.Statement;
 import boomerang.scene.Val;
@@ -34,6 +35,9 @@ public class UsagePatternResultsListener implements IResultsListener {
     public UsagePatternResultsListener(Collection<Assertion> assertions) {
         this.assertions = assertions;
     }
+
+    @Override
+    public void constructedCallGraph(CallGraph callGraph) {}
 
     @Override
     public void typestateAnalysisResults(IAnalysisSeed analysisSeed, ForwardBoomerangResults<TransitionFunction> results) {

--- a/HeadlessAndroidScanner/src/main/java/de/fraunhofer/iem/android/HeadlessAndroidScanner.java
+++ b/HeadlessAndroidScanner/src/main/java/de/fraunhofer/iem/android/HeadlessAndroidScanner.java
@@ -12,6 +12,7 @@ import crypto.analysis.errors.AbstractError;
 import crypto.cryslhandler.RulesetReader;
 import crypto.definition.ScannerDefinition;
 import crypto.exceptions.CryptoAnalysisParserException;
+import crypto.listener.AnalysisStatistics;
 import crypto.preanalysis.TransformerSetup;
 import crypto.reporting.Reporter;
 import crypto.reporting.ReporterFactory;
@@ -137,10 +138,11 @@ public class HeadlessAndroidScanner {
 		Collection<CrySLRule> ruleset = scanner.getRuleset();
 		Collection<IAnalysisSeed> discoveredSeeds = scanner.getDiscoveredSeeds();
 		Table<WrappedClass, Method, Set<AbstractError>> errors = scanner.getCollectedErrors();
+		AnalysisStatistics statistics = scanner.getStatistics();
 		Collection<Reporter> reporters = ReporterFactory.createReporters(getReportFormats(), getReportDirectory(), ruleset);
 
 		for (Reporter reporter : reporters) {
-			reporter.createAnalysisReport(discoveredSeeds, errors);
+			reporter.createAnalysisReport(discoveredSeeds, errors, statistics);
 		}
 	}
 


### PR DESCRIPTION
During the refactoring for the new Boomerang version, the analysis statistics in reports got lost due to the changed API of the call graph and statements. This adds the statistics, e.g. the analysis time, back to reports