### PR TITLE
change execution context of the dependabot automerge workflow

### DIFF
--- a/.github/workflows/approve_dependabotifications.yml
+++ b/.github/workflows/approve_dependabotifications.yml
@@ -1,5 +1,7 @@
 name: Dependabot auto-approve
-on: pull_request
+on:
+  pull_request_target:
+   paths: ["pom.xml"]
 
 permissions:
   contents: write


### PR DESCRIPTION
trigger on pull_request_target to get context of base branch and only…on pom change i.e. allow only pom to change by dependabot

if that still has permissions issues - see https://stackoverflow.com/questions/70664840/automatic-merging-of-dependabot-generated-pull-request-with-codeowners-file-and