### PR TITLE
Fix edges in state machine when dealing with optionals

### DIFF
--- a/CryptoAnalysis/src/main/java/crypto/analysis/AnalysisSeedWithSpecification.java
+++ b/CryptoAnalysis/src/main/java/crypto/analysis/AnalysisSeedWithSpecification.java
@@ -859,9 +859,6 @@ public class AnalysisSeedWithSpecification extends IAnalysisSeed {
         Collection<ISLConstraint> remainingPredicates = new HashSet<>(requiredPredicates);
 
         for (ISLConstraint pred : requiredPredicates) {
-            Collection<Map.Entry<EnsuredCrySLPredicate, Integer>> predsAtStatement =
-                    ensuredPredicates.get(pred.getLocation());
-
             if (pred instanceof RequiredCrySLPredicate) {
                 RequiredCrySLPredicate reqPred = (RequiredCrySLPredicate) pred;
 
@@ -873,6 +870,8 @@ public class AnalysisSeedWithSpecification extends IAnalysisSeed {
                 }
 
                 // Check for basic required predicates, e.g. randomized
+                Collection<Map.Entry<EnsuredCrySLPredicate, Integer>> predsAtStatement =
+                        ensuredPredicates.get(reqPred.getLocation());
                 int reqParamIndex = reqPred.getParamIndex();
                 for (Map.Entry<EnsuredCrySLPredicate, Integer> ensPredAtIndex : predsAtStatement) {
                     if (doReqPredAndEnsPredMatch(
@@ -899,6 +898,8 @@ public class AnalysisSeedWithSpecification extends IAnalysisSeed {
                                 .filter(CrySLPredicate::isNegated)
                                 .collect(Collectors.toList());
 
+                Collection<Map.Entry<EnsuredCrySLPredicate, Integer>> predsAtStatement =
+                        ensuredPredicates.get(altPred.getLocation());
                 for (Map.Entry<EnsuredCrySLPredicate, Integer> ensPredAtIndex : predsAtStatement) {
                     // If any positive alternative is satisfied, the whole predicate is satisfied
                     if (positives.stream()
@@ -967,7 +968,7 @@ public class AnalysisSeedWithSpecification extends IAnalysisSeed {
                 // Check for basic negated required predicates, e.g. randomized
                 CrySLPredicate invertedPred = reqPred.getPred().invertNegation();
                 Collection<Map.Entry<EnsuredCrySLPredicate, Integer>> predsAtStatement =
-                        ensuredPredicates.get(pred.getLocation());
+                        ensuredPredicates.get(reqPred.getLocation());
 
                 for (Map.Entry<EnsuredCrySLPredicate, Integer> ensPredAtIndex : predsAtStatement) {
                     if (doReqPredAndEnsPredMatch(

--- a/CryptoAnalysis/src/main/java/crypto/cryslhandler/StateMachineGraphBuilder.java
+++ b/CryptoAnalysis/src/main/java/crypto/cryslhandler/StateMachineGraphBuilder.java
@@ -183,6 +183,13 @@ public class StateMachineGraphBuilder {
                 right = buildSubSMG(order.getRight(), left.getEndNodes());
                 start.addAll(left.getStartNodes());
                 end.addAll(right.getEndNodes());
+
+                for (StateNode node : startNodes) {
+                    if (left.getEndNodes().contains(node)) {
+                        start.addAll(right.getStartNodes());
+                    }
+                }
+
                 break;
             case ALTERNATIVE:
                 left = buildSubSMG(order.getLeft(), startNodes);

--- a/CryptoAnalysis/src/main/java/crypto/rules/CrySLConstraint.java
+++ b/CryptoAnalysis/src/main/java/crypto/rules/CrySLConstraint.java
@@ -1,6 +1,5 @@
 package crypto.rules;
 
-import boomerang.scene.Statement;
 import java.util.List;
 
 public class CrySLConstraint implements ISLConstraint {
@@ -15,7 +14,6 @@ public class CrySLConstraint implements ISLConstraint {
     private final LogOps operator;
     private final ISLConstraint left;
     private final ISLConstraint right;
-    private Statement location;
 
     public CrySLConstraint(ISLConstraint l, ISLConstraint r, LogOps op) {
         left = l;
@@ -62,10 +60,5 @@ public class CrySLConstraint implements ISLConstraint {
     @Override
     public String getName() {
         return toString();
-    }
-
-    @Override
-    public Statement getLocation() {
-        return location;
     }
 }

--- a/CryptoAnalysis/src/main/java/crypto/rules/CrySLExceptionConstraint.java
+++ b/CryptoAnalysis/src/main/java/crypto/rules/CrySLExceptionConstraint.java
@@ -1,6 +1,5 @@
 package crypto.rules;
 
-import boomerang.scene.Statement;
 import java.util.Collections;
 import java.util.List;
 
@@ -15,8 +14,6 @@ public class CrySLExceptionConstraint implements ISLConstraint {
 
     /** The Exception thrown by the Method. */
     private final CrySLException exception;
-
-    private Statement location = null;
 
     /**
      * Construct the {@link CrySLExceptionConstraint} given the method and the exception thrown
@@ -50,11 +47,6 @@ public class CrySLExceptionConstraint implements ISLConstraint {
 
     public String toString() {
         return String.format("%s(%s, %s)", this.getClass().getName(), getMethod(), getException());
-    }
-
-    @Override
-    public Statement getLocation() {
-        return this.location;
     }
 
     @Override

--- a/CryptoAnalysis/src/main/java/crypto/rules/CrySLLiteral.java
+++ b/CryptoAnalysis/src/main/java/crypto/rules/CrySLLiteral.java
@@ -1,14 +1,6 @@
 package crypto.rules;
 
-import boomerang.scene.Statement;
-
 public abstract class CrySLLiteral implements ISLConstraint {
 
-    private Statement location;
-
     protected CrySLLiteral() {}
-
-    public Statement getLocation() {
-        return location;
-    }
 }

--- a/CryptoAnalysis/src/main/java/crypto/rules/ISLConstraint.java
+++ b/CryptoAnalysis/src/main/java/crypto/rules/ISLConstraint.java
@@ -5,5 +5,4 @@ import java.util.List;
 public interface ISLConstraint extends ICrySLPredicateParameter {
 
     List<String> getInvolvedVarNames();
-
 }

--- a/CryptoAnalysis/src/main/java/crypto/rules/ISLConstraint.java
+++ b/CryptoAnalysis/src/main/java/crypto/rules/ISLConstraint.java
@@ -1,11 +1,9 @@
 package crypto.rules;
 
-import boomerang.scene.Statement;
 import java.util.List;
 
 public interface ISLConstraint extends ICrySLPredicateParameter {
 
     List<String> getInvolvedVarNames();
 
-    Statement getLocation();
 }

--- a/CryptoAnalysis/src/test/java/test/UsagePatternTestingFramework.java
+++ b/CryptoAnalysis/src/test/java/test/UsagePatternTestingFramework.java
@@ -94,8 +94,7 @@ public abstract class UsagePatternTestingFramework extends AbstractTestingFramew
     @Override
     protected SceneTransformer createAnalysisTransformer() throws ImprecisionException {
 
-        // Required since Soot 4.3.0
-        Options.v().setPhaseOption("jb.sils", "enabled:false");
+        Options.v().setPhaseOption("jb", "use-original-names:false");
 
         return new SceneTransformer() {
 

--- a/CryptoAnalysis/src/test/java/test/assertions/InAcceptingStateAssertion.java
+++ b/CryptoAnalysis/src/test/java/test/assertions/InAcceptingStateAssertion.java
@@ -15,6 +15,7 @@ public class InAcceptingStateAssertion implements Assertion, StateResult {
     public InAcceptingStateAssertion(Statement unit, Collection<Val> val) {
         this.unit = unit;
         this.val = val;
+        this.satisfied = false;
     }
 
     public Collection<Val> getVal() {
@@ -41,6 +42,6 @@ public class InAcceptingStateAssertion implements Assertion, StateResult {
 
     @Override
     public String toString() {
-        return "[" + val + "@" + unit + " must not be in error state]";
+        return "[" + val + " @ " + unit + " must not be in error state]";
     }
 }

--- a/CryptoAnalysis/src/test/java/test/assertions/NotInAcceptingStateAssertion.java
+++ b/CryptoAnalysis/src/test/java/test/assertions/NotInAcceptingStateAssertion.java
@@ -15,6 +15,7 @@ public class NotInAcceptingStateAssertion implements Assertion, StateResult {
     public NotInAcceptingStateAssertion(Statement unit, Collection<Val> accessGraph) {
         this.unit = unit;
         this.val = accessGraph;
+        this.satisfied = true;
     }
 
     public Collection<Val> getVal() {
@@ -26,7 +27,7 @@ public class NotInAcceptingStateAssertion implements Assertion, StateResult {
     }
 
     public void computedResults(State s) {
-        satisfied |= !s.isAccepting();
+        satisfied &= !s.isAccepting();
     }
 
     @Override
@@ -41,6 +42,6 @@ public class NotInAcceptingStateAssertion implements Assertion, StateResult {
 
     @Override
     public String toString() {
-        return "[" + val + "@" + unit + " must not be in error state]";
+        return "[" + val + " @ " + unit + " must not be in accepting state]";
     }
 }

--- a/CryptoAnalysis/src/test/java/tests/jca/CogniCryptTestGenTest.java
+++ b/CryptoAnalysis/src/test/java/tests/jca/CogniCryptTestGenTest.java
@@ -90,6 +90,97 @@ public class CogniCryptTestGenTest extends UsagePatternTestingFramework {
 
     @Test
     @SuppressWarnings("ConstantConditions")
+    public void keyStoreInvalidTest7()
+            throws NoSuchAlgorithmException,
+                    IOException,
+                    KeyStoreException,
+                    CertificateException,
+                    UnrecoverableEntryException {
+
+        // Related to issue 295: https://github.com/CROSSINGTUD/CryptoAnalysis/issues/295
+        char[] passwordKey = null;
+        String aliasGet = null;
+        String alias = null;
+        Entry entry = null;
+        String keyStoreAlgorithm = null;
+        String aliasSet = null;
+        ProtectionParameter protParamSet = null;
+        LoadStoreParameter paramStore = null;
+        ProtectionParameter protParamGet = null;
+
+        KeyStore keyStore0 = KeyStore.getInstance(keyStoreAlgorithm);
+        // loads skipped
+        keyStore0.getEntry(aliasGet, protParamGet);
+        Key key = keyStore0.getKey(alias, passwordKey);
+        keyStore0.setEntry(aliasSet, entry, protParamSet);
+        keyStore0.store(paramStore);
+        Assertions.notHasEnsuredPredicate(key);
+        Assertions.mustNotBeInAcceptingState(keyStore0);
+    }
+
+    @Test
+    @SuppressWarnings("ConstantConditions")
+    public void keyStoreInvalidTest8()
+            throws NoSuchAlgorithmException,
+                    IOException,
+                    KeyStoreException,
+                    CertificateException,
+                    UnrecoverableEntryException {
+
+        // Related to issue 295: https://github.com/CROSSINGTUD/CryptoAnalysis/issues/295
+        char[] passwordKey = null;
+        String aliasGet = null;
+        String alias = null;
+        Entry entry = null;
+        String keyStoreAlgorithm = null;
+        String aliasSet = null;
+        ProtectionParameter protParamSet = null;
+        LoadStoreParameter paramStore = null;
+        ProtectionParameter protParamGet = null;
+
+        KeyStore keyStore0 = KeyStore.getInstance(keyStoreAlgorithm, (Provider) null);
+        // loads skipped
+        keyStore0.getEntry(aliasGet, protParamGet);
+        Key key = keyStore0.getKey(alias, passwordKey);
+        keyStore0.setEntry(aliasSet, entry, protParamSet);
+        keyStore0.store(paramStore);
+        Assertions.notHasEnsuredPredicate(key);
+        Assertions.mustNotBeInAcceptingState(keyStore0);
+    }
+
+    @Test
+    @SuppressWarnings("ConstantConditions")
+    public void keyStoreInvalidTest9()
+            throws NoSuchAlgorithmException,
+                    IOException,
+                    KeyStoreException,
+                    CertificateException,
+                    UnrecoverableEntryException {
+
+        // Related to issue 295: https://github.com/CROSSINGTUD/CryptoAnalysis/issues/295
+        char[] passwordKey = null;
+        String aliasGet = null;
+        String alias = null;
+        Entry entry = null;
+        String keyStoreAlgorithm = null;
+        String aliasSet = null;
+        ProtectionParameter protParamSet = null;
+        OutputStream fileoutput = null;
+        char[] passwordOut = null;
+        ProtectionParameter protParamGet = null;
+
+        KeyStore keyStore0 = KeyStore.getInstance(keyStoreAlgorithm);
+        // loads skipped
+        keyStore0.getEntry(aliasGet, protParamGet);
+        Key key = keyStore0.getKey(alias, passwordKey);
+        keyStore0.setEntry(aliasSet, entry, protParamSet);
+        keyStore0.store(fileoutput, passwordOut);
+        Assertions.notHasEnsuredPredicate(key);
+        Assertions.mustNotBeInAcceptingState(keyStore0);
+    }
+
+    @Test
+    @SuppressWarnings("ConstantConditions")
     public void keyStoreInvalidTest10()
             throws NoSuchAlgorithmException,
                     UnrecoverableKeyException,

--- a/CryptoAnalysis/src/test/java/tests/jca/PBETest.java
+++ b/CryptoAnalysis/src/test/java/tests/jca/PBETest.java
@@ -66,6 +66,7 @@ public class PBETest extends UsagePatternTestingFramework {
         Assertions.hasGeneratedPredicate(pbekeyspec);
         Assertions.mustNotBeInAcceptingState(pbekeyspec);
         pbekeyspec.clearPassword();
+        Assertions.mustBeInAcceptingState(pbekeyspec);
         pbekeyspec = new PBEKeySpec(corPwd, salt, 9999, 128);
         Assertions.extValue(1);
         Assertions.extValue(2);
@@ -73,6 +74,7 @@ public class PBETest extends UsagePatternTestingFramework {
         Assertions.hasNotGeneratedPredicate(pbekeyspec);
         Assertions.mustNotBeInAcceptingState(pbekeyspec);
         pbekeyspec.clearPassword();
+        Assertions.mustBeInAcceptingState(pbekeyspec);
 
         PBEParameterSpec pbeParSpec1 = new PBEParameterSpec(salt, 10000);
         Assertions.extValue(0);

--- a/HeadlessJavaScanner/src/test/java/scanner/targets/BouncyCastleHeadlessTest.java
+++ b/HeadlessJavaScanner/src/test/java/scanner/targets/BouncyCastleHeadlessTest.java
@@ -213,7 +213,7 @@ public class BouncyCastleHeadlessTest extends AbstractHeadlessTest {
         addErrorSpecification(
                 new ErrorSpecification.Builder(
                                 "pluotsorbet.BouncyCastleSHA256", "testSHA256DigestTwo", 0)
-                        .withTPs(TypestateError.class, 4)
+                        .withTPs(TypestateError.class, 1)
                         .withTPs(ImpreciseValueExtractionError.class, 1)
                         .build());
 

--- a/pom.xml
+++ b/pom.xml
@@ -420,7 +420,6 @@
                             <include>CryptoAnalysis/pom.xml</include>
                             <include>HeadlessAndroidScanner/pom.xml</include>
                             <include>HeadlessJavaScanner/pom.xml</include>
-                            <include>ScannerTests/pom.xml</include>
                         </includes>
                         <sortPom>
                             <encoding>UTF-8</encoding>


### PR DESCRIPTION
For expressions in the `ORDER` section of the form `(Op1?, Op2)*`, the state machine is missing an edge. Currently, there are tree states `0`, `1` and `2` with the edges `0 --Op1--> 1`, `1 --Op2--> 2`, `0 --Op2--> 2` and `2 --Op1--> 1`. This forces to use `Op1` after using `Op2` and being in state `2`. However, since `Op1` is optional, there is a missing edge `2 --Op2--> 2` that models using `Op2` mulitple times. This edge is added with this PR.

Close #295 