### PR TITLE
Allow build_and_test.yml to be triggered manually

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -8,6 +8,7 @@ on:
       - develop
   pull_request:
     types: [opened, reopened]
+  workflow_dispatch:
 
 env:
   JAVA_VERSION: 17


### PR DESCRIPTION
GitHub bot PRs do not trigger build actions. Therefore, we allow them to be triggered manually for the merge queue.