### PR TITLE
Add plugin property to Android scanner

### DIFF
--- a/HeadlessAndroidScanner/src/main/resources/plugin.properties
+++ b/HeadlessAndroidScanner/src/main/resources/plugin.properties
@@ -1,0 +1,2 @@
+# Required by emf.core
+_UI_DiagnosticRoot_diagnostic=_UI_DiagnosticRoot_diagnostic


### PR DESCRIPTION
The Android scanner is missing a plugin property that causes xtext to crash