### PR TITLE
Fix assertion extraction in CryptoAnalysis tests

### DIFF
--- a/CryptoAnalysis/src/test/java/test/TestRunner.java
+++ b/CryptoAnalysis/src/test/java/test/TestRunner.java
@@ -196,9 +196,14 @@ public class TestRunner {
         }
         visited.add(method);
 
-        for (CallGraph.Edge callSite : callGraph.edgesInto(method)) {
-            Method callee = callSite.tgt();
-            extractBenchmarkMethods(callee, callGraph, queries, visited);
+        for (Statement statement : method.getStatements()) {
+            for (CallGraph.Edge edge : callGraph.edgesOutOf(statement)) {
+                Method callee = edge.tgt();
+
+                if (callee.isDefined()) {
+                    extractBenchmarkMethods(callee, callGraph, queries, visited);
+                }
+            }
         }
 
         for (Statement statement : method.getStatements()) {

--- a/CryptoAnalysis/src/test/java/tests/jca/SecretKeyTest.java
+++ b/CryptoAnalysis/src/test/java/tests/jca/SecretKeyTest.java
@@ -288,7 +288,7 @@ public class SecretKeyTest {
 
         public byte[] encrypt(String plainText) throws GeneralSecurityException {
             byte[] encText = this.cipher.doFinal(plainText.getBytes());
-            Assertions.hasEnsuredPredicate(encText);
+            Assertions.notHasEnsuredPredicate(encText);
             return encText;
         }
     }


### PR DESCRIPTION
When extracting the assertions from the test methods, CryptoAnalysis considers only the orgininal test method and no other methods. This is because it tries to traverse the call graph in opposite direction, i.e. it tries to find other methods by looking on edges that lead into the test method. However, since the test method is the entry point, there are no other methods. Instead, it has to check the methods that are exiting the test method, i.e. the methods out of the initial test method. Recursively, CryptoAnalysis then checks all reachable methods in the call graph.

Thanks to @Hazem-Gamall for spotting this mistake