### PR TITLE
Fix report generation and build caching for Github action

### DIFF
--- a/CryptoAnalysis/src/main/java/crypto/reporting/GitHubAnnotationReporter.java
+++ b/CryptoAnalysis/src/main/java/crypto/reporting/GitHubAnnotationReporter.java
@@ -156,12 +156,6 @@ public class GitHubAnnotationReporter extends CommandLineReporter {
         setSummary(summary.toString());
 
         System.out.println("::endgroup::");
-
-        super.createAnalysisReport(seeds, errorCollection, statistics);
-
-        if (errorCount != 0) {
-            System.exit(1);
-        }
     }
 
     private Path classToSourcePath(WrappedClass clazz) {

--- a/action.yml
+++ b/action.yml
@@ -24,8 +24,6 @@ inputs:
       Running this action will also implicitly enable the output as GitHub Annotations.
   visualization :
     description: Enables the visualization, but also requires reportPath option to be set
-  providerDetection :
-    description: Enables provider detection analysis
   ignoreSections:
     description: Names of packages, classes and methods to be ignored during the analysis.
       This input expects path to a file containing one name per line.
@@ -102,7 +100,7 @@ runs:
     # This also makes the action work for non-releases,
     # meaning any ref that can be resolved by https://github.com/actions/checkout.
     - name: Compile CryptoAnalysis
-      # if: steps.cache.outputs.cache-hit != 'true' && steps.download.outcome != 'success'
+      if: steps.cache.outputs.cache-hit != 'true' && steps.download.outcome != 'success'
       shell: bash
       run: |
         echo "::group::Compile"


### PR DESCRIPTION
Fixes two bugs I while I was trying to use CryptoAnalysis as a Github action.
* When running the Github action with reportPath and reportFormat set, CryptoAnalysis will generate a report both for github_annotation and the other format. However, if there are any errors detected by the scanner, the program will exit after generating this report. If github_annotation is the first one generated (the reporters are stored in a set, meaning the order is random), then this will lead to the second report format not being generated. I simply removed the System.exit call and the report generation in the command line.
* The action would always compile the JAR, even if it there was a cache hit, which is redundant and unnecessary. A simple uncommenting of the if was sufficient. I also removed the unused providerDetection parameter.

This action now runs properly on my repo. 
Here is a screenshot of the tests passing. I cannot run the Android scanner one since I seem to be missing an android.jar file in test resources, however the changes are only on the GitHub action and in CryptoAnalysis.

<img width="710" height="155" alt="image" src="https://github.com/user-attachments/assets/d885b685-5bb8-474b-a077-de217fa4b71c" />