### PR TITLE
Use Platformclassloader instead of Parentclassloader

### DIFF
--- a/CryptoAnalysis/src/main/java/crypto/analysis/ClassPathHandler.java
+++ b/CryptoAnalysis/src/main/java/crypto/analysis/ClassPathHandler.java
@@ -44,7 +44,7 @@ public class ClassPathHandler {
                         .toList();
 
         classLoader =
-                new URLClassLoader(urls.toArray(new URL[0]), ClassLoader.getSystemClassLoader());
+                new URLClassLoader(urls.toArray(new URL[0]), ClassLoader.getPlatformClassLoader());
     }
 
     public static URLClassLoader getClassLoader() {


### PR DESCRIPTION
This fixes a problem if the analyzed code has the same dependencies as Cognicrypt but in a conflicting version. In our case this was triggered by protobuf. 
The PlatformClassLoader does not contain the classes that are needed by the analysis itself. 

Maybe there should be some documentation that the default analysis runs the analyzed code (or at least its static initializers) for a subtype check. 



